### PR TITLE
[GEN-174] Skeleton structure of the climb detail view for the competition

### DIFF
--- a/trk/src/Screens/ClimbDetail/index.js
+++ b/trk/src/Screens/ClimbDetail/index.js
@@ -27,8 +27,30 @@ function ClimbDetail(props) {
         console.error("Error getting setter image URL: ", error);
       });
   }, []);
- 
+ if (climbData.set==='Competition') {
   return (
+    <View style={styles.container}>
+      <View style={[styles.wrapper]}>
+      <SafeAreaView />
+      <View style={styles.top}>
+        <View style={styles.topLeft}>
+          <View style={styles.gradeCircle}>
+            <Text>{climbData.grade}</Text>
+          </View>
+
+          <Text style={styles.titleText}>{climbData.name}</Text>
+        </View>
+        <View style={styles.setterCircle}>
+          { setterImageUrl ? <Image source={{ uri: setterImageUrl }} style={{width: '100%', height: '100%'}} /> : <Text>Loading...</Text> }
+        </View>
+      </View>
+      <View style={styles.line}></View>
+      </View>
+    </View>
+  )
+ }
+ else 
+{  return (
     <View style={styles.container}>
     <View style={[styles.wrapper]} >
       <SafeAreaView />
@@ -51,7 +73,7 @@ function ClimbDetail(props) {
 
     </View>
     </View>
-  )
+  )}
 }
 
 const styles = StyleSheet.create({

--- a/trk/src/Screens/ClimbDetail/index.js
+++ b/trk/src/Screens/ClimbDetail/index.js
@@ -40,11 +40,15 @@ function ClimbDetail(props) {
 
           <Text style={styles.titleText}>{climbData.name}</Text>
         </View>
-        <View style={styles.setterCircle}>
-          { setterImageUrl ? <Image source={{ uri: setterImageUrl }} style={{width: '100%', height: '100%'}} /> : <Text>Loading...</Text> }
-        </View>
       </View>
       <View style={styles.line}></View>
+      <Text>IFSC score: {climbData.ifsc}</Text>
+      <Text>Type: {climbData.type}</Text>
+      <Text>% complete</Text>
+      <Text>Number of attemps</Text>
+      <Text>Witness 1</Text>
+      <Text>Witness 2</Text>
+  
       </View>
     </View>
   )


### PR DESCRIPTION
Made if/else statement so that if climb set = 'Competition', the climbdetail returned is different than for commercial boulder. Side by side view for the read of a climb with set = "Commercial" and set = "Competition" 
![IMG_9539](https://github.com/nagimonyc/trk-app/assets/126114238/6b79a12a-ea71-4d9e-b7a7-9071c5d06087)
![IMG_9538](https://github.com/nagimonyc/trk-app/assets/126114238/bd8b1112-97ac-465b-9311-17493f58d8b5)
