### PR TITLE
[GEN-46] Set Detail for setter clicking on a climb

### DIFF
--- a/trk/src/Components/ClimbItem.js
+++ b/trk/src/Components/ClimbItem.js
@@ -1,20 +1,45 @@
-import React from 'react';
+import React, {useState, useEffect} from 'react';
 import { View, Text, Image, StyleSheet, TouchableOpacity } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
+import { AuthContext } from '../Utils/AuthContext';
+import storage from '@react-native-firebase/storage';
 
 const ClimbItem = ({ climb, tapId }) => {
+    const [imageURL, setImageURL] = useState(null);
     const navigation = useNavigation();
+    const { role } = React.useContext(AuthContext);
+
+    useEffect(() => {
+        const fetchImageURL = async () => {
+            try {
+                const url = await storage().ref('profile photos/marcial.png').getDownloadURL();
+                setImageURL(url);
+            } catch (error) {
+                console.error('Failed to fetch image URL:', error);
+            }
+        };
+
+        fetchImageURL();
+    }, []);
 
     const navigateToDetail = () => {
         navigation.navigate('Detail', { climbData: climb, tapId: tapId, profileCheck: 1 });
     };
+    const navigateToSet = () => {
+        navigation.navigate('Set', {climbData: climb})
+    };
 
     return (
-        <TouchableOpacity onPress={navigateToDetail}>
+        <TouchableOpacity onPress={role === 'climber' ? navigateToDetail : navigateToSet}>
             <View style={styles.climbContainer}>
-                <View style={styles.climbDot}></View>
+                <View style={styles.climbDot}>
+                    <Text style={styles.grade}>{climb.grade}</Text>
+                </View>
                 <Image source={{ uri: climb.image }} style={styles.climbImage} />
-                <Text>{climb.name}</Text>
+                <Text style={styles.climbName}>{climb.name}</Text>
+                <View style={styles.setterDot}>
+                <Image source={{ uri: imageURL }} style={{ width: '100%', height: '100%' }} />
+                </View>
             </View>
         </TouchableOpacity>
     );
@@ -30,18 +55,40 @@ const styles = StyleSheet.create({
         borderRadius: 5,
     },
     climbDot: {
-        width: 10,
-        height: 10,
-        borderRadius: 5,
+        width: 30,
+        height: 30,
+        borderRadius: 15,
         backgroundColor: 'grey', // Change to desired color
-        marginRight: 10,
+        marginRight: 1,
+        marginLeft: 10,
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: '#C73B3B',
+    },
+    grade: {
+        color: 'white',
+    },
+    climbName: {
+        fontWeight: '700',
+        flex: 1,
     },
     climbImage: {
         width: 30, // Adjust as needed
         height: 30, // Adjust as needed
         borderRadius: 15,
-        marginRight: 10,
-    }
+        marginRight: 1,
+    },
+    setterDot: {
+        width: 30,
+        height: 30,
+        borderRadius: 15,
+        backgroundColor: 'grey', // Change to desired color
+        marginRight: 5,
+        marginLeft: 60,
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: '#CBB092',
+    },
 });
 
 export default ClimbItem;

--- a/trk/src/Components/SetterProfile.js
+++ b/trk/src/Components/SetterProfile.js
@@ -6,7 +6,7 @@ import ClimbsApi from "../api/ClimbsApi";
 import firestore from '@react-native-firebase/firestore';
 import { firebase } from "@react-native-firebase/auth";
 
-const SetterProfile = () => {
+const SetterProfile = (props) => {
 
     const { currentUser } = React.useContext(AuthContext);
 
@@ -21,7 +21,7 @@ const SetterProfile = () => {
             const setSnapshot = await getClimbsBySomeField('setter', currentUser.uid);
             console.log('setSnapshot:', setSnapshot);  // Log the snapshot here
             const newSetHistory = setSnapshot.docs.map(doc => {
-                return doc.exists ? doc.data() : null;
+                return doc.exists ? { id: doc.id, ...doc.data() } : null;
             }).filter(set => set !== null);
             console.log('newSetHistory:', newSetHistory);  // Log the processed climbs here
             setSetHistory(newSetHistory);

--- a/trk/src/Navigation/AppNavigator.js
+++ b/trk/src/Navigation/AppNavigator.js
@@ -10,6 +10,7 @@ import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import UserProfile from '../Screens/Profile';
 import { AuthContext } from '../Utils/AuthContext';
 import ClimberPerformance from '../Components/ClimberPerformance';
+import SetDetail from '../Screens/SetDetail';
 
 
 const Stack = createStackNavigator();
@@ -33,6 +34,7 @@ function ProfileStack() {
       {/* removed the header for the 'home' screen as the two homescreens stacked on top of one another and showed 2 'Home' headers */}
       <Stack.Screen name="Profile" component={UserProfile} />
       <Stack.Screen name="Detail" component={ClimbDetailScreen} />
+      <Stack.Screen name="Set" component={SetDetail} />
     </Stack.Navigator>
   );
 }

--- a/trk/src/Screens/SetDetail/index.js
+++ b/trk/src/Screens/SetDetail/index.js
@@ -1,0 +1,187 @@
+import React, { useState, useEffect } from 'react';
+import { Alert } from 'react-native';
+import { View, Text, StyleSheet, SafeAreaView, Image, TextInput, Button } from 'react-native';
+import storage from '@react-native-firebase/storage';
+import firestore from '@react-native-firebase/firestore';
+
+
+function SetDetail(props) {
+  console.log('[TEST] SetDetail called')
+
+  const { climbData } = props.route.params;
+  console.log(`Climb id is ${climbData.id}`)
+
+  const [tapCount, setTapCount] = useState(0);
+  const [climbImageUrl, setClimbImageUrl] = useState(null);
+  const [setterImageUrl, setSetterImageUrl] = useState(null);
+
+
+  useEffect(() => {
+    const fetchTapCount = async () => {
+      try {
+        const tapQuerySnapshot = await firestore()
+          .collection('taps')
+          .where('climb', '==', climbData.id)
+          .get();
+          
+        setTapCount(tapQuerySnapshot.size);
+      } catch (error) {
+        console.error('Error fetching tap count:', error);
+      }
+    };
+
+    fetchTapCount();
+  }, [climbData.id]);
+
+
+  useEffect(() => {
+    console.log(`photo is : ${climbData.photo}`)
+    const climbReference = climbData.photo ? storage().ref(`${climbData.photo}`) : storage().ref('climb photos/the_crag.png');
+    climbReference.getDownloadURL()
+      .then((url) => {
+        setClimbImageUrl(url);
+      })
+      .catch((error) => {
+        console.error("Error getting climb image URL: ", error);
+      });
+
+    const setterReference = storage().ref('profile photos/marcial.png');
+    setterReference.getDownloadURL()
+      .then((url) => {
+        setSetterImageUrl(url);
+      })
+      .catch((error) => {
+        console.error("Error getting setter image URL: ", error);
+      });
+  }, []);
+
+  return (
+    <View style={styles.container}>
+    <View style={[styles.wrapper]} >
+      <SafeAreaView />
+      <View style={styles.top}>
+        <View style={styles.topLeft}>
+          <View style={styles.gradeCircle}>
+            <Text style={styles.grade}>{climbData.grade}</Text>
+          </View>
+
+          <Text style={styles.titleText}>{climbData.name}</Text>
+        </View>
+        <View style={styles.circleWrapper}>
+        <View style={styles.setterCircle}>
+        <Image source={{ uri: setterImageUrl }} style={{ width: '100%', height: '100%' }} /> 
+        </View>
+        </View>
+      </View>
+      <View style={styles.countBox}>
+      <Text style={styles.count}>{tapCount}</Text>
+      </View>
+      <View style={styles.climbPhoto}>
+      <Image source={{ uri: climbImageUrl }} style={{ width: '100%', height: '100%' }} />
+      </View>
+
+    </View>
+  </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+
+  wrapper: {
+    width: 317,
+    height: 539.89,
+    alignItems: 'center',
+    padding: 15,
+    backgroundColor: 'white',
+    borderRadius: 8.78,
+    borderColor: '#f2f2f2',
+    borderWidth: 1.49,
+  },
+  top: {
+    flexDirection: 'row',
+    marginTop: 20,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+
+  titleText: {
+    flexShrink: 1, // To prevent text overflow
+    fontWeight: 'bold',
+    marginLeft: 15,
+    fontSize: 17.57,
+  },
+
+  topLeft: {
+    flexDirection: 'row',
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  gradeCircle: {
+    width: 50,
+    height: 50,
+    borderRadius: 25,
+    backgroundColor: '#C73B3B', //this color is hardcoded for now, but needs to match the level/grading system of the gym
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  setterCircle: {
+    width: 90,
+    height: 90,
+    borderRadius: 45,
+    backgroundColor: 'white',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginLeft: 20,
+    overflow: 'hidden',
+  },
+  line: {
+    width: 200,
+    height: 1,
+    borderTopWidth: 1,
+    borderColor: 'rgba(0, 0, 0, 0.26)',
+    marginTop: 55,
+  },
+
+  climbPhoto: {
+    width: 197,
+    height: 287,
+    marginTop: 15,
+    backgroundColor: 'white',
+    borderRadius: 3.88,
+  },
+  contentArea: {
+    padding: 10,  // Add padding around the content
+    width: '100%',
+  },
+  group: {
+    marginBottom: 10,
+    marginTop: 10,  // Add space below each group
+  },
+  title: {
+    fontWeight: 'bold',
+  },
+  countBox: {
+    marginTop: 15,
+  },
+  count: {
+    fontSize: 45,
+    fontWeight: '700'
+  },
+  circleWrapper: {
+    width: 100,  // or whatever width keeps your layout consistent
+    alignItems: 'center',
+    justifyContent: 'center',
+    flex: 0
+  },
+  grade: {
+    color: 'white',
+  },
+})
+
+export default SetDetail;


### PR DESCRIPTION
![IMG_9679](https://github.com/nagimonyc/trk-app/assets/126114238/40df591c-2045-4874-b94e-ddb9285ab21b)
![IMG_9680](https://github.com/nagimonyc/trk-app/assets/126114238/b3357723-b554-4be3-a0f8-10b181c5cccd)

Create a new screen called SetDetail, added it to AppNav in the ProfileStack, made SetterProfile pass down the climb document id in its props, built SetDetail to show climb grade, name, setter photo (saved in storage, always marcial), and the climb photo (individual storage path saved in climb document field called 'photo', if no 'photo' field exists, it uses the default photo also held in storage)