### PR TITLE
[GEN-195] Tie Break

### DIFF
--- a/trk/src/Screens/CompRanking/index.js
+++ b/trk/src/Screens/CompRanking/index.js
@@ -26,28 +26,33 @@ const CompRanking = () => {
                     const climbsSnapshots = await Promise.all(climbsPromises);
 
                     let totalIFSC = 0;
+                    let totalAttempts = 0;
                     climbsSnapshots.forEach((climbSnapshot, index) => {
                         if (climbSnapshot.exists) {
                             const climb = climbSnapshot.data();
                             const tap = tapsSnapshot.docs[index].data();
-                            let adjustedScore = parseInt(climb.ifsc, 10) * tap.completion;  // Adjust the score
+                            let adjustedScore = parseInt(climb.ifsc, 10) * tap.completion;
                             totalIFSC += adjustedScore;
+
+                            totalAttempts += tap.attempts;  // Add the number of attempts from the tap data
                         }
                     });
 
                     return {
                         ...userData,
                         userId,
-                        totalIFSC  // Store the adjusted total IFSC score
+                        totalIFSC,
+                        totalAttempts
                     };
                 })
             );
             const sortedUserData = allUserData.sort((a, b) => {
-                // If a's score is NaN, give it a low value; otherwise, use its score
                 const aScore = isNaN(a.totalIFSC) ? -Infinity : a.totalIFSC;
-                // If b's score is NaN, give it a low value; otherwise, use its score
                 const bScore = isNaN(b.totalIFSC) ? -Infinity : b.totalIFSC;
 
+                if (bScore === aScore) {
+                    return a.totalAttempts - b.totalAttempts;  // Fewer attempts come first
+                }
                 return bScore - aScore;
             });
 


### PR DESCRIPTION
- Breaking ties by # of attempts

-> tested, it works. Though, it does what it is supposed to do, and shows how some further tweaking w/ James is necessary. E.g., a tie in points where one participant has completed more climbs than the other but has more # of attempts on each is ranked lower than someone who has completed fewer climbs but with fewer attempts.

Obviously, there should be more than just # attempts to break ties.