### PR TITLE
[GEN-241] Setter profile photo android crash fix

### DIFF
--- a/trk/src/Components/ClimbItem.js
+++ b/trk/src/Components/ClimbItem.js
@@ -65,7 +65,7 @@ const styles = StyleSheet.create({
         width: 30,
         height: 30,
         borderRadius: 15,
-        backgroundColor: '#CBB092',
+        backgroundColor: 'white',
         marginRight: 5,
         marginLeft: 60,
         alignItems: 'center',

--- a/trk/src/Components/ClimbItem.js
+++ b/trk/src/Components/ClimbItem.js
@@ -35,7 +35,7 @@ const ClimbItem = ({ climb, tapId }) => {
                 <Image source={{ uri: climb.image }} style={styles.climbImage} />
                 <Text style={styles.climbName}>{climb.name}</Text>
                 <View style={styles.setterDot}>
-                    <Image source={{ uri: imageURL }} style={{ width: '100%', height: '100%' }} />
+                {imageURL && <Image source={{ uri: imageURL }} style={{ width: '100%', height: '100%' }} />}
                 </View>
             </ListItemContainer>
         </TouchableOpacity>


### PR DESCRIPTION
The imageURL for the setter is only displayed when it is not null. It's background color is the same as the individual climber containers so it's invisible when loading