### PR TITLE
[GEN-337] Default setter photo and default or path-specific climb photo for climbDetail 

### DIFF
--- a/trk/src/Components/ClimbItem.js
+++ b/trk/src/Components/ClimbItem.js
@@ -32,7 +32,6 @@ const ClimbItem = ({ climb, tapId }) => {
     return (
         <TouchableOpacity onPress={role === 'climber' ? navigateToDetail : navigateToSet}>
             <ListItemContainer dotStyle={styles.climbDot}>
-                {climb.image && <Image source={{ uri: climb.image }} style={styles.climbImage} />}
                 <Text style={styles.climbName}>{climb.name}</Text>
                 <View style={styles.setterDot}>
                     {imageURL && <Image source={{ uri: imageURL }} style={{ width: '100%', height: '100%' }} />}

--- a/trk/src/Screens/ClimbDetail/index.js
+++ b/trk/src/Screens/ClimbDetail/index.js
@@ -63,7 +63,25 @@ function ClimbDetail(props) {
   }, [props.route.params.profileCheck, props.route.params.tapId]);  // dependencies array
 
 
+  useEffect(() => {
+    const climbReference = climbData.photo ? storage().ref(`${climbData.photo}`) : storage().ref('climb photos/the_crag.png');
+    climbReference.getDownloadURL()
+      .then((url) => {
+        setClimbImageUrl(url);
+      })
+      .catch((error) => {
+        console.error("Error getting climb image URL: ", error);
+      });
 
+    const setterReference = storage().ref('profile photos/marcial.png');
+    setterReference.getDownloadURL()
+      .then((url) => {
+        setSetterImageUrl(url);
+      })
+      .catch((error) => {
+        console.error("Error getting setter image URL: ", error);
+      });
+  }, []);
 
 
   const handleUpdate = async () => {
@@ -105,30 +123,6 @@ function ClimbDetail(props) {
       return parseInt(value, 10) - 1;
     }
   };
-
-
-
-  // useEffect(() => {
-  //   const climbReference = storage().ref('climb photos/the_crag.png');
-  //   climbReference.getDownloadURL()
-  //     .then((url) => {
-  //       setClimbImageUrl(url);
-  //     })
-  //     .catch((error) => {
-  //       console.error("Error getting climb image URL: ", error);
-  //     });
-
-  //   const setterReference = storage().ref('profile photos/epset.png');
-  //   setterReference.getDownloadURL()
-  //     .then((url) => {
-  //       setSetterImageUrl(url);
-  //     })
-  //     .catch((error) => {
-  //       console.error("Error getting setter image URL: ", error);
-  //     });
-  // }, []);
-
-
 
   if (climbData.set === 'Competition') {
     return (
@@ -301,7 +295,7 @@ const styles = StyleSheet.create({
     width: 90,
     height: 90,
     borderRadius: 45,
-    backgroundColor: '#CDB58F',
+    backgroundColor: 'white',
     alignItems: 'center',
     justifyContent: 'center',
     marginLeft: 50,
@@ -319,7 +313,7 @@ const styles = StyleSheet.create({
     width: 197,
     height: 287,
     marginTop: 42,
-    backgroundColor: '#ff9a00',
+    backgroundColor: 'white',
     borderRadius: 3.88,
   },
   contentArea: {


### PR DESCRIPTION
ONLY FOR CLIMBERS: commercial climbs showed 'Loading...' upon read or navigation from profile, now they display a default photo or the photo stored in the pathway if specified on climb document. 
N.B for routesetter view, this functionality was already implemented

**Before:**
![IMG_0228](https://github.com/nagimonyc/trk-app/assets/126114238/468ad9b7-2d58-4ab8-9f82-168116942842)


**After:**
![IMG_0227](https://github.com/nagimonyc/trk-app/assets/126114238/5fa92b2d-dbe4-4c22-8238-622f23da8481)
