### PR TITLE
[GEN-303] Feedback displayed to routesetters on setdetail

### DIFF
--- a/trk/src/Screens/SetDetail/index.js
+++ b/trk/src/Screens/SetDetail/index.js
@@ -71,9 +71,12 @@ function SetDetail(props) {
           comments.push({
             id: doc.id,
             explanation: commentData.explanation,
-            rating: commentData.rating  // Extracting the rating field
+            rating: commentData.rating,
+            timestamp: commentData.timestamp  // Assuming this is a Firestore timestamp
           });
         });
+        // Sort comments by timestamp in descending order
+        comments.sort((a, b) => b.timestamp.toDate() - a.timestamp.toDate());
         setFeedbackList(comments);
       } catch (error) {
         console.error('Error fetching comments:', error);

--- a/trk/src/api/CommentsApi.js
+++ b/trk/src/api/CommentsApi.js
@@ -1,0 +1,20 @@
+import firebase from "@react-native-firebase/app";
+import "@react-native-firebase/firestore";
+
+
+function CommentsApi() {
+
+  const ref = firebase.firestore().collection("comments");
+  console.log('[DATABASE] CommentsApi called');
+
+  // get comments by some field
+  function getCommentsBySomeField(field, value) {
+    return ref.where(field, '==', value).get();
+  };
+
+  return {
+    getCommentsBySomeField,
+  };
+}
+
+export default CommentsApi;


### PR DESCRIPTION
Coded:
- Api to search a comments document by somefield
- used this api to sift through comments that have the same climb id as the climb being displayed on setdetail
- the explanation and rating for this comment are saved in an array
- the array of feedback is displayed if not empty, and if empty, it says no feedback 
![ezgif com-video-to-gif](https://github.com/nagimonyc/trk-app/assets/126114238/488269e4-9174-4b1d-a46f-8c5e058f1d4e)
![387417675_192344677279360_7610065055385848374_n](https://github.com/nagimonyc/trk-app/assets/126114238/4fc48db6-8872-42e5-b9ea-b55cad09c387)
![370115156_382776287532838_6018450857856667722_n](https://github.com/nagimonyc/trk-app/assets/126114238/1fbb56e9-b26b-4610-b1b2-aaa4e3674325)
