### PR TITLE
[GEN-393] Climb descriptors and glossary

### DIFF
--- a/trk/src/Navigation/AppNavigator.js
+++ b/trk/src/Navigation/AppNavigator.js
@@ -13,6 +13,7 @@ import ClimberPerformance from '../Components/ClimberPerformance';
 import SetDetail from '../Screens/SetDetail';
 import Settings from '../Components/Settings';
 import FeedbackForm from '../Screens/FeedbackForm';
+import GlossaryDefinition from '../Screens/GlossaryDefinition';
 
 
 const Stack = createStackNavigator();
@@ -36,6 +37,11 @@ function HomeStack() {
         name="Feedback"
         component={FeedbackForm}
         options={{ title: 'Feedback Form', headerBackTitle: 'Climb Detail', headerTitleAlign: 'center' }}
+      />
+      <Stack.Screen
+        name="Definition"
+        component={GlossaryDefinition}
+        options={{ title: 'Definition', headerBackTitle: 'Climb Detail', headerTitleAlign: 'center' }}
       />
     </Stack.Navigator>
   );
@@ -64,6 +70,11 @@ function ProfileStack() {
         name="Feedback"
         component={FeedbackForm}
         options={{ title: 'Feedback Form', headerBackTitle: 'Back', headerTitleAlign: 'center' }}
+      />
+        <Stack.Screen
+        name="Definition"
+        component={GlossaryDefinition}
+        options={{ title: 'Definition', headerBackTitle: 'Back', headerTitleAlign: 'center' }}
       />
     </Stack.Navigator>
   );

--- a/trk/src/Screens/ClimbDetail/index.js
+++ b/trk/src/Screens/ClimbDetail/index.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Alert } from 'react-native';
 import TapsApi from '../../api/TapsApi';
 
-import { View, Text, StyleSheet, ScrollView, SafeAreaView, Image, TextInput, Button, TouchableWithoutFeedback, Keyboard, Share } from 'react-native';
+import { View, Text, StyleSheet, ScrollView, SafeAreaView, Image, TextInput, Button, TouchableWithoutFeedback, Keyboard, Share, TouchableOpacity } from 'react-native';
 
 import storage from '@react-native-firebase/storage';
 import SegmentedControl from '@react-native-segmented-control/segmented-control';
@@ -155,6 +155,11 @@ function ClimbDetail(props) {
     navigation.navigate('Feedback', { climbName: climbData.name, climbGrade: climbData.grade, climbId: climbId })
   };
 
+  const onDefinition = (descriptor) => {
+    navigation.navigate('Definition', { descriptor: descriptor });
+  };
+  
+
   const getSelectedIndex = (value) => {
     if (value === '⚡️') {
       return 0;  // '⚡️' represents a '1', so return 0 for the index
@@ -274,10 +279,22 @@ function ClimbDetail(props) {
                 </View>
               </View>
               <View style={styles.line}></View>
+              <View style={styles.descriptorsContainer}>
+                {climbData.descriptors && climbData.descriptors.map((descriptor, index) => (
+                  <TouchableOpacity
+                    key={index}
+                    style={styles.descriptorButton}
+                    onPress={() => onDefinition(descriptor)}
+                    activeOpacity={0.6} 
+                  >
+                    <Text style={styles.descriptorText}>{descriptor}</Text>
+                  </TouchableOpacity>
+                ))}
+              </View>
+
               <View style={styles.climbPhoto}>
                 {climbImageUrl ? <Image source={{ uri: climbImageUrl }} style={{ width: '100%', height: '100%' }} /> : <Text>Loading...</Text>}
               </View>
-             
               <View style={{ marginTop: 20 }}>
                 <View style={styles.button}>
                   <Button title='Review this climb' onPress={onFeedback} />
@@ -290,7 +307,7 @@ function ClimbDetail(props) {
                 <View style={styles.infoBox}>
                   <Text style={styles.subheading}>Climb Info</Text>
                   <Text style= {styles.info}>{climbData.info}</Text>
-                  </View>
+                </View>
               )}
             </View>
           </View>
@@ -367,7 +384,7 @@ const styles = StyleSheet.create({
   climbPhoto: {
     width: 197,
     height: 287,
-    marginTop: 42,
+    marginTop: 22,
     backgroundColor: 'white',
     borderRadius: 3.88,
   },
@@ -389,19 +406,43 @@ const styles = StyleSheet.create({
     marginTop: 15,
     alignSelf: 'flex-start',
     marginLeft: 30,
-  
+
   },
   subheading: {
     fontWeight: '700',
     fontSize: 20,
-    textAlign: 'left', 
+    textAlign: 'left',
   },
   info: {
     marginTop: 5,
     fontSize: 16,
-    textAlign: 'left', 
+    textAlign: 'left',
     marginBottom: 10,
-  }, 
+  },
+  descriptorsContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginVertical: 10,  // Add vertical margin for spacing
+  },
+  descriptorButton: {
+    marginHorizontal: 5,
+    marginTop: 10,
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    backgroundColor: '#e7e7e7', // Slightly different background color
+    borderRadius: 5,
+    borderWidth: 1,
+    borderColor: '#e7e7e7', // Add border
+  },
+  
+  descriptorText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#007AFF', // Color indicating it's clickable (like a link)
+  },
+  
 })
 
 export default ClimbDetail;

--- a/trk/src/Screens/GlossaryDefinition/index.js
+++ b/trk/src/Screens/GlossaryDefinition/index.js
@@ -1,0 +1,89 @@
+import React, { useState, useEffect } from "react";
+import { Text,  View, ScrollView, SafeAreaView, StyleSheet, Image } from "react-native";
+import DescriptorsApi from "../../api/DescriptorsApi";
+import storage from '@react-native-firebase/storage';
+
+const GlossaryDefinition = ({ route }) => {
+
+  const { descriptor } = route.params;
+  const [definition, setDefinition] = useState('');
+  const [photoUrl, setPhotoUrl] = useState(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const api = DescriptorsApi();
+      try {
+        const querySnapshot = await api.getDescriptorsBySomeField('descriptor', descriptor);
+        if (!querySnapshot.empty) {
+          const doc = querySnapshot.docs[0];
+          const data = doc.data();
+          setDefinition(data.definition);
+
+          // Fetching the image URL from Firebase Storage
+          const photoRef = data.photo ? storage().ref(`${data.photo}`) : storage().ref('default/path/to/image.png');
+          photoRef.getDownloadURL()
+            .then((url) => {
+              setPhotoUrl(url);
+            })
+            .catch((error) => {
+              console.error("Error getting photo URL: ", error);
+            });
+        } else {
+          console.log('No matching document found');
+        }
+      } catch (error) {
+        console.error('Error fetching descriptor:', error);
+      }
+    };
+
+    fetchData();
+  }, [descriptor]);
+
+  return (
+    <ScrollView>
+      <SafeAreaView>
+        <View style={styles.container}>
+          <View style={styles.wrapper}>
+            <Text style={styles.titleText}>{descriptor}</Text>
+            <Text style={styles.definitionText}>{definition}</Text>
+            {photoUrl && <Image source={{ uri: photoUrl }} style={styles.image} />} 
+          </View>
+        </View>
+      </SafeAreaView>
+    </ScrollView>
+  )
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  wrapper: {
+    width: '90%',
+    marginTop: 5,
+    alignItems: 'center',
+    padding: 15,
+    backgroundColor: 'white',
+    borderRadius: 8.78,
+    borderColor: '#f2f2f2',
+    borderWidth: 1.49,
+  },
+  titleText: {
+    fontWeight: 'bold',
+    fontSize: 18,
+  },
+  definitionText: {
+    marginTop: 15,
+  },
+  image:{
+    width: '100%',
+    height: 287,
+    marginTop: 22,
+    backgroundColor: 'white',
+    borderRadius: 3.88,
+  }
+});
+
+export default GlossaryDefinition

--- a/trk/src/api/DescriptorsApi.js
+++ b/trk/src/api/DescriptorsApi.js
@@ -1,0 +1,20 @@
+import firebase from "@react-native-firebase/app";
+import "@react-native-firebase/firestore";
+
+
+function DescriptorsApi() {
+
+  const ref = firebase.firestore().collection("descriptors");
+  console.log('[DATABASE] DescriptorsApi called');
+
+  // get descriptors by some field
+  function getDescriptorsBySomeField(field, value) {
+    return ref.where(field, '==', value).get();
+  };
+
+  return {
+    getDescriptorsBySomeField,
+  };
+}
+
+export default DescriptorsApi;


### PR DESCRIPTION
**In this PR:**
- creation of descriptors collection (each descriptor doc has 3 fields: the descriptor, the definition, and the photo to illustrate the definition)
- descriptors api created to get descriptors by some field,
- glossaryDefinition screen that displays the descriptor, definition and image
- navigation set up to be able to navigate to glossaryDefiniton from home and profile
- Display of clickable descriptors in climbdetail which navigate to glossaryDefinition

![ezgif com-video-to-gif](https://github.com/nagimonyc/trk-app/assets/126114238/c0e8e1cb-ad53-4dfc-b52e-6694ec5e9c09)

<img width="1222" alt="Screenshot 2023-12-06 at 12 24 58 AM" src="https://github.com/nagimonyc/trk-app/assets/126114238/273f5b0c-47cd-40ca-b0e6-95e05c538cab">

<img width="769" alt="Screenshot 2023-12-06 at 12 26 08 AM" src="https://github.com/nagimonyc/trk-app/assets/126114238/fed87bb6-1221-4931-9915-ac40ca78399f">
