### PR TITLE
[GEN-318] Navigation to climbDetail upon successful NFC read even with no wifi

### DIFF
--- a/trk/src/Screens/Home/index.js
+++ b/trk/src/Screens/Home/index.js
@@ -48,44 +48,24 @@ function HomeScreen(props) {
     if (Platform.OS === 'android') {
       androidPromptRef.current.setVisible(true);
     }
-
+  
     try {
       await NfcManager.requestTechnology(NfcTech.NfcA);
-      const { getClimb } = ClimbsApi();
-      const climbId = await readClimb();
-      const climbData = await getClimb(climbId[0]); // Fetch climb data using ID
-      if (climbData.exists) { //check if climb exists and if the user is the setter, if not, allow them to read the climb
-        if (currentUser.uid !== climbData.data().setter) {
-          const { addTap } = TapsApi();
-          const tap = {
-            climb: climbId[0],
-            user: currentUser.uid,
-            timestamp: new Date(),
-            completion: 0,
-            attempts: '',
-            witness1: '',
-            witness2: '',
-          }
-          const documentReference = await addTap(tap);
-          const newTapId = documentReference.id;
-          navigation.navigate('Detail', { climbData: climbData.data(), tapId: newTapId, climbId: climbId[0] });
-        } else {
-          navigation.navigate('Detail', { climbData: climbData.data(), climbId: climbId[0] })
-        }
-
+      const climbId = await readClimb(); // Read climb ID from NFC tag
+      if (climbId && climbId[0]) {
+        navigation.navigate('Detail', { climbId: climbId[0], isFromHome: true }); // Navigate with climbId
       } else {
-        Alert.alert('Error', 'Climb not found!', [{ text: 'OK' }]);
+        throw new Error('Invalid climb ID'); // Handle invalid climb ID
       }
     } catch (ex) {
-      // console.warn(ex);
+      Alert.alert('Error', ex.message || 'Climb not found!', [{ text: 'OK' }]);
     } finally {
       NfcManager.cancelTechnologyRequest();
+      if (Platform.OS === 'android') {
+        androidPromptRef.current.setVisible(false);
+      }
     }
-
-    if (Platform.OS === 'android') {
-      androidPromptRef.current.setVisible(false);
-    }
-
+  
     analytics().logEvent('Tap to Track pressed', {
       user_id: currentUser.uid,
       timestamp: new Date().toISOString()


### PR DESCRIPTION
**Overview**
- navigation to climbDetail upon successful NFC climbID retrieval
- climbData retrieval in firestore and taps creation only occur after navigation (executed in climbDetail rather than home)
- fixes in state management of constants in climbdetail which are prop drilled from profile but no longer from home.

**This is what happens if you read a climb with no wifi/4G**

![387417676_734011078621407_8017746503799448705_n](https://github.com/nagimonyc/trk-app/assets/126114238/9aadcd06-8746-42a0-8eab-3844a8fcfb9f)
