### PR TITLE
[Android Store Build Version Update]

### DIFF
--- a/trk/android/app/build.gradle
+++ b/trk/android/app/build.gradle
@@ -79,8 +79,8 @@ android {
         applicationId "com.nagimo.Nagimo"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 11
-        versionName "11.0"
+        versionCode 12
+        versionName "12.0"
     }
     signingConfigs {
         debug {


### PR DESCRIPTION
The latest Android builds weren't uploaded to the Google Play Store. Strange.

I believe it is because I was only _**editing**_ the current Release (with new builds), instead of _**creating**_ a new one.
But.. 1) There was no 'create new release' button (had to discard the existing one, then one appeared), and 2) why.. editing doesn't edit? #GooglePlayConsoleThings