### PR TITLE
[GEN-458] Image Edit Feature for Route Setter

### DIFF
--- a/trk/ios/Podfile.lock
+++ b/trk/ios/Podfile.lock
@@ -1591,7 +1591,7 @@ SPEC CHECKSUMS:
   React-Core: aaacca67f9ca54f142827e67f44bfbd815875eb6
   React-CoreModules: 32fab1d62416849a3b6dac6feff9d54e5ddc2d1e
   React-cxxreact: 37765b4975541105b2a3322a4b473417c158c869
-  React-debug: 9a8c41b6b03f50f44a32030a3cd93a06daa86f5c
+  React-debug: feff3727d91cc34c3f425eba6dc449256f964157
   React-hermes: 935ae71fb3d7654e947beba8498835cd5e479707
   React-jsi: ec628dc7a15ffea969f237b0ea6d2fde212b19dd
   React-jsiexecutor: 59d1eb03af7d30b7d66589c410f13151271e8006
@@ -1601,7 +1601,7 @@ SPEC CHECKSUMS:
   react-native-pager-view: cf96a223846458cc7e932017636b5c6d8cc2c549
   react-native-safe-area-context: 7aa8e6d9d0f3100a820efb1a98af68aa747f9284
   react-native-segmented-control: 2221962f5073e2e809aa3691e8e410fc10b60578
-  React-NativeModulesApple: 729813bbdacdfff5732e6457b328ce2d48a185b4
+  React-NativeModulesApple: 828af790356ea4ec7e472d74493d81a3cc2e7af0
   React-perflogger: 6bd153e776e6beed54c56b0847e1220a3ff92ba5
   React-RCTActionSheet: c0b62af44e610e69d9a2049a682f5dba4e9dff17
   React-RCTAnimation: fe7005136b58f58871cab2f70732343b6e330d30
@@ -1615,9 +1615,9 @@ SPEC CHECKSUMS:
   React-RCTVibration: ea3a68a49873a54ced927c90923fc6932baf344a
   React-rncore: 9672a017af4a7da7495d911f0b690cbcae9dd18d
   React-runtimeexecutor: 369ae9bb3f83b65201c0c8f7d50b72280b5a1dbc
-  React-runtimescheduler: 513d7b0c4292efc646fb66f414cbb52c665cf1b9
-  React-utils: 833a34b9c1cd1bec019361b704ac3128988c114e
-  ReactCommon: b75d2271cbb99f818df90d7a5cd830e0dc95c89a
+  React-runtimescheduler: 2359c039f38bf2ea38ab22629d2f0bf53f05f628
+  React-utils: e9716fa24b691496e2a23650168a4840101ba895
+  ReactCommon: cd9b989bf8ac0219a081a1c915b8c38853a3dd37
   RecaptchaInterop: 7d1a4a01a6b2cb1610a47ef3f85f0c411434cb21
   RNCMaskedView: 0e1bc4bfa8365eba5fbbb71e07fbdc0555249489
   RNFastImage: 5c9c9fed9c076e521b3f509fe79e790418a544e8

--- a/trk/src/Screens/ClimbDetail/index.js
+++ b/trk/src/Screens/ClimbDetail/index.js
@@ -36,7 +36,7 @@ function ClimbDetail(props) {
           if (climbDataResult && climbDataResult._data) {
             setClimbData(climbDataResult._data);
             console.log("Fetched climb data:", climbDataResult._data);
-  
+
             if (currentUser.uid !== climbDataResult._data.setter) {
               const { addTap } = TapsApi();
               const tap = {
@@ -50,7 +50,7 @@ function ClimbDetail(props) {
               };
               const documentReference = await addTap(tap);
               setTapId(documentReference.id); // Set tapId only when navigating from home
-            } 
+            }
           } else {
             console.error('Climb data not found or is null');
           }
@@ -63,7 +63,7 @@ function ClimbDetail(props) {
       fetchData();
     }
   }, [climbId, isFromHome, currentUser.uid]);
-  
+
 
   useEffect(() => {
     const fetchData = async () => {
@@ -108,16 +108,27 @@ function ClimbDetail(props) {
 
 
   useEffect(() => {
-    if (climbData) {
-    const climbReference = climbData.image ? storage().ref(`climb_image/${climbId}`) : storage().ref('climb photos/the_crag.png');
-    climbReference.getDownloadURL()
-      .then((url) => {
-        setClimbImageUrl(url);
-      })
-      .catch((error) => {
-        console.error("Error getting climb image URL: ", error);
-      });
+    // Function to load the image URL from Firebase Storage
+    const loadImage = (imagePath) => {
+      storage().ref(imagePath).getDownloadURL()
+        .then((url) => {
+          setClimbImageUrl(url);
+        })
+        .catch((error) => {
+          console.error("Error getting image URL: ", error);
+        });
+    };
 
+    if (climbData && climbData.images && climbData.images.length > 0) {
+      // Load the latest climb image
+      const latestImageRef = climbData.images[climbData.images.length - 1];
+      loadImage(latestImageRef.path);
+    } else {
+      // Load the default image from Firebase Storage
+      loadImage('climb photos/the_crag.png');
+    }
+
+    // Load the setter image (same logic as before)
     const setterReference = storage().ref('profile photos/marcial.png');
     setterReference.getDownloadURL()
       .then((url) => {
@@ -126,7 +137,6 @@ function ClimbDetail(props) {
       .catch((error) => {
         console.error("Error getting setter image URL: ", error);
       });
-    }
   }, [climbData]);
 
 
@@ -215,8 +225,8 @@ function ClimbDetail(props) {
         <Text>Fetching climb information...</Text>
       </View>
     );
-  //  the reason i put this here is because we will eventually display name and grade here when we encode it onto the nfc tags 
-  //  right now it means that if there is no wifi, something is shown on screen
+    //  the reason i put this here is because we will eventually display name and grade here when we encode it onto the nfc tags 
+    //  right now it means that if there is no wifi, something is shown on screen
   } else if (climbData.set === 'Competition') {
     return (
       <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>


### PR DESCRIPTION
- Allows route setters to modify images of their set climbs

How is this implemented?
- 3 files changed: Create Form, Set Details, and Climb Details.
1. Create form: changes how climbs are stored in the firestore storage and in the firestore collection, by adding images to an array (each with an "id", and a "path"). This provides code flexibility to how we may display images in future improvements.
 
<img width="606" alt="Screenshot 2023-12-15 at 1 15 10 pm" src="https://github.com/nagimonyc/trk-app/assets/66965648/b27daf29-8b02-430e-8d3e-ce7a21e51f99">

2. Set / Climb details: Changed the way images get retrieved, accounting for our previous way of storing images.

Worth noting: images are now stored in "climb_images/" instead of "climb_image/". This keeps all old images in the old folder, not conflicting with the new images.


- 3 images: before - edit form - after

![4A2ED78C-75EE-4A50-A45F-B51D6FBB4A74_1_102_o](https://github.com/nagimonyc/trk-app/assets/66965648/b4141d99-efcc-41cb-9c95-5a44617ed317)

![5DFF9E7C-2E39-4C05-85FC-B7845C8EB373_1_102_o](https://github.com/nagimonyc/trk-app/assets/66965648/affd0786-416d-4d47-b8b3-d2d1a8d2d8d8)

![CA7098F1-2238-4324-B345-17AA38F3B4AF_1_102_o](https://github.com/nagimonyc/trk-app/assets/66965648/5233c6b7-83c8-4c08-beb8-ec5d6b06fbb6)

