### PR TITLE
[GEN-204] Delete Tap functionality for Climbers

### DIFF
--- a/trk/src/Screens/ClimbDetail/index.js
+++ b/trk/src/Screens/ClimbDetail/index.js
@@ -390,11 +390,6 @@ function ClimbDetail(props) {
                 <View style={styles.button}>
                   <Button title='Share' onPress={onShare} />
                 </View>
-                {role == 'climber' && <>
-                <View style={styles.button}>
-                <Button title='Delete Tap' onPress={archiveTap} color="black" />
-                </View>
-                </>}
               </View>
               {climbData.info && (
                 <View style={styles.infoBox}>
@@ -402,6 +397,11 @@ function ClimbDetail(props) {
                   <Text style={styles.info}>{climbData.info}</Text>
                 </View>
               )}
+              {role == 'climber' && <>
+                <View style={styles.button}>
+                <Button title='Delete Tap' onPress={archiveTap} color="black" />
+                </View>
+                </>}
             </View>
           </View>
         </ScrollView>

--- a/trk/src/Screens/ClimbDetail/index.js
+++ b/trk/src/Screens/ClimbDetail/index.js
@@ -22,7 +22,7 @@ function ClimbDetail(props) {
   const [attempts, setAttempts] = useState('1');
   const [witness1, setWitness1] = useState('');
   const [witness2, setWitness2] = useState('');
-  const { currentUser } = useContext(AuthContext);
+  const { currentUser, role } = useContext(AuthContext);
   const [tapId, setTapId] = useState(props.route.params.tapId || null);
 
 
@@ -203,6 +203,35 @@ function ClimbDetail(props) {
     }
   };
 
+  const archiveTap = async () => {
+        Alert.alert(
+            "Delete Tap",
+            "Do you really want to delete this tap?",
+            [
+                {
+                    text: "Cancel",
+                    onPress: () => console.log("Cancel Pressed"),
+                    style: "cancel"
+                },
+                { 
+                    text: "Yes", 
+                    onPress: async () => {
+                        try {
+                            await TapsApi().updateTap(tapId, { archived: true });
+                            Alert.alert("Tap Deleted", "The tap has been successfully deleted.");
+                            props.navigation.goBack();
+                        } catch (error) {
+                            console.error("Error deleting tap:", error);
+                            Alert.alert("Error", "Could not delete tap.");
+                        }
+                    } 
+                }
+            ]
+        );
+    };
+
+
+
   const onFeedback = async () => {
     navigation.navigate('Feedback', { climbName: climbData.name, climbGrade: climbData.grade, climbId: climbId })
   };
@@ -361,6 +390,11 @@ function ClimbDetail(props) {
                 <View style={styles.button}>
                   <Button title='Share' onPress={onShare} />
                 </View>
+                {role == 'climber' && <>
+                <View style={styles.button}>
+                <Button title='Delete Tap' onPress={archiveTap} color="black" />
+                </View>
+                </>}
               </View>
               {climbData.info && (
                 <View style={styles.infoBox}>

--- a/trk/src/Screens/GymDaily/index.js
+++ b/trk/src/Screens/GymDaily/index.js
@@ -87,7 +87,7 @@ const GymDaily = () => {
             tap.timestamp = tap.timestamp.toDate();
             console.log(`Tap Timestamp: ${tap.timestamp}`);
             return tap;
-          });
+          }).filter(tap => tap !== null && (tap.archived === undefined || tap.archived === false));
           totalTaps += taps.length;
           allTaps = [...allTaps, ...taps];
 

--- a/trk/src/Screens/Home/index.js
+++ b/trk/src/Screens/Home/index.js
@@ -33,28 +33,27 @@ function HomeScreen(props) {
       const climbDetailsPromises = querySnapshot.docs.map(async (doc) => {
         const tapData = doc.data();
         const climbSnapshot = await getClimb(tapData.climb);
-        // Extract and format the timestamp
+        
         let timestamp = tapData.timestamp;
-        if (timestamp.toDate) { // Convert Firebase Timestamp to JavaScript Date
-          timestamp = timestamp.toDate().toLocaleTimeString('en-US', {
-            hour: '2-digit',
-            minute: '2-digit',
-            hour12: true,
-            timeZone: 'America/New_York' // NEW YORK TIME
-          });
+        if (timestamp.toDate) {
+            timestamp = timestamp.toDate().toLocaleTimeString('en-US', {
+                hour: '2-digit',
+                minute: '2-digit',
+                hour12: true,
+                timeZone: 'America/New_York'
+            });
         }
+    
         return climbSnapshot.exists ? {
-          ...tapData,
-          tapTimestamp: timestamp,
-          tapId: doc.id,
-          ...climbSnapshot.data(),
+            ...tapData,
+            tapTimestamp: timestamp,
+            tapId: doc.id,
+            ...climbSnapshot.data(),
         } : null;
-      });
-
-
+    });
 
       const newClimbsHistory = (await Promise.all(climbDetailsPromises))
-        .filter(tap => tap !== null);
+        .filter(tap => tap !== null && (tap.archived === undefined || tap.archived === false));
 
       setClimbsHistory(newClimbsHistory);
     });

--- a/trk/src/Screens/Home_Backend/HomeScreenLogic.js
+++ b/trk/src/Screens/Home_Backend/HomeScreenLogic.js
@@ -51,7 +51,7 @@ export const useHomeScreenLogic = (props) => {
 
 
       const newClimbsHistory = (await Promise.all(climbDetailsPromises))
-        .filter(tap => tap !== null);
+        .filter(tap => tap !== null && (tap.archived === undefined || tap.archived === false));
 
       setClimbsHistory(newClimbsHistory);
     });


### PR DESCRIPTION
- Created a Delete Tap button on ClimbDetail.js (only appears for climbers, not routesetters)
- This locates the tap by id and adds 'archived: true' to the object
- Returns to the previous page and reloads it to reflect changes (useFocusEffect, tested  with Firebase)
- The tap is archived (archived: true property added in firestore), and can be still viewed in firestore. Appears like deletion to the user

For Climbers
![image](https://github.com/nagimonyc/trk-app/assets/75244191/a1ab97a4-52f4-4761-a9a3-ee93b7ee9052)

Fore Routesetters
![image](https://github.com/nagimonyc/trk-app/assets/75244191/ea36cee8-e0c4-4ecb-8ef4-c7c329387c4f)
