### PR TITLE
[GEN-478] Fixes to NFC read for manual cancelling and unwritten tag (ClimbDetail)

### DIFF
--- a/trk/src/Screens/ClimbDetail/index.js
+++ b/trk/src/Screens/ClimbDetail/index.js
@@ -35,6 +35,22 @@ function ClimbDetail(props) {
           const climbDataResult = await ClimbsApi().getClimb(climbId);
           if (climbDataResult && climbDataResult._data) {
             setClimbData(climbDataResult._data);
+            console.log("Fetched climb data:", climbDataResult._data);
+
+            if (currentUser.uid !== climbDataResult._data.setter) {
+              const { addTap } = TapsApi();
+              const tap = {
+                climb: climbId,
+                user: currentUser.uid,
+                timestamp: new Date(),
+                completion: 0,
+                attempts: '',
+                witness1: '',
+                witness2: '',
+              };
+              const documentReference = await addTap(tap);
+              setTapId(documentReference.id); // Set tapId only when navigating from home
+            }
           } else {
             Alert.alert(
               "Error",

--- a/trk/src/Screens/ClimbDetail/index.js
+++ b/trk/src/Screens/ClimbDetail/index.js
@@ -35,35 +35,29 @@ function ClimbDetail(props) {
           const climbDataResult = await ClimbsApi().getClimb(climbId);
           if (climbDataResult && climbDataResult._data) {
             setClimbData(climbDataResult._data);
-            console.log("Fetched climb data:", climbDataResult._data);
-
-            if (currentUser.uid !== climbDataResult._data.setter) {
-              const { addTap } = TapsApi();
-              const tap = {
-                climb: climbId,
-                user: currentUser.uid,
-                timestamp: new Date(),
-                completion: 0,
-                attempts: '',
-                witness1: '',
-                witness2: '',
-              };
-              const documentReference = await addTap(tap);
-              setTapId(documentReference.id); // Set tapId only when navigating from home
-            }
           } else {
-            console.error('Climb data not found or is null');
+            Alert.alert(
+              "Error",
+              "Climb data not found.",
+              [{ text: "OK", onPress: () => navigation.goBack() }],
+              { cancelable: false }
+            );
           }
         } catch (error) {
           console.error('Error fetching climb data:', error);
+          Alert.alert(
+            "Error",
+            "Failed to load climb data.",
+            [{ text: "OK", onPress: () => navigation.goBack() }],
+            { cancelable: false }
+          );
         } finally {
           setIsLoading(false);
         }
       }
       fetchData();
     }
-  }, [climbId, isFromHome, currentUser.uid]);
-
+  }, [climbId, isFromHome, currentUser.uid, navigation]);  
 
   useEffect(() => {
     const fetchData = async () => {
@@ -248,7 +242,7 @@ function ClimbDetail(props) {
     }
   };
 
-  if (isLoading) {
+  if (isLoading || !climbData) {
     return (
       <View style={styles.center}>
         <Text>Fetching climb information...</Text>


### PR DESCRIPTION
- Adjusted the catch block with a boolean variable to track if reading or not (displays message accordingly, on manual canceling).
- When reading an unwritten tag, the app used to crash with an error saying "null property not defined". Fixed it by altering useeffect a bit to check for valid climbData, and only proceeding to rendering with valid data.

When cancelled
![image](https://github.com/nagimonyc/trk-app/assets/75244191/367ad712-d83c-48c2-89f2-7525c1141083)

When no climb is written on the tag already
![image](https://github.com/nagimonyc/trk-app/assets/75244191/20545928-6680-4c25-90f2-7a3b1e7cb379)
