### PR TITLE
[GEN-446] Writing and reading grade (sample), through NFC tag

### DIFF
--- a/trk/src/NfcUtils/readClimb.js
+++ b/trk/src/NfcUtils/readClimb.js
@@ -2,25 +2,30 @@ import NfcManager from 'react-native-nfc-manager';
 
 async function readClimb() {
   let climbIdBytes = [];
+  let gradeBytes = [];
 
-  // Read 16 bytes starting from block 4
+  // Read 16 bytes starting from block 4 (default)
   let respBytes = await NfcManager.nfcAHandler.transceive([0x30, 4]);
   if (respBytes.length !== 16) {
     throw new Error('Fail to read starting block 4');
   }
   climbIdBytes = [...climbIdBytes, ...respBytes.slice(0, 16)];
 
-  // Read 4 bytes starting from block 8
+  // Read 16 bytes starting from block 8 (default)
   respBytes = await NfcManager.nfcAHandler.transceive([0x30, 8]);
   if (respBytes.length !== 16) {
     throw new Error('Fail to read starting block 8');
   }
   climbIdBytes = [...climbIdBytes, ...respBytes.slice(0, 4)];
+  gradeBytes = [...gradeBytes, ...respBytes.slice(4, 8)];
 
   // Reconstruct Firestore Document ID
   const climbId = String.fromCharCode.apply(null, climbIdBytes).trim();
-
-  return [climbId, climbIdBytes];
+  //Reconstructed climb grade string
+  const grade = String.fromCharCode.apply(null, gradeBytes).trim();
+  console.log('The grade is: ', grade);
+  console.log('Proceeding...');
+  return [climbId, climbIdBytes, grade];
 }
 
 export default readClimb;

--- a/trk/src/NfcUtils/verifySignature.js
+++ b/trk/src/NfcUtils/verifySignature.js
@@ -2,9 +2,9 @@ import NfcManager from 'react-native-nfc-manager';
 import * as HexUtils from '../Utils/HexUtils';
 import * as Signer from '../Utils/Signer';
 
-async function verifySignature(pokemonBytes) {
+async function verifySignature(climbBytes) {
   const tag = await NfcManager.getTag();
-  const msgHex = HexUtils.bytesToHex(pokemonBytes) + tag.id;
+  const msgHex = HexUtils.bytesToHex(climbBytes) + tag.id;
   // console.warn('msg', msgHex);
 
   const sigPageIdx = 12;

--- a/trk/src/NfcUtils/writeSignature.js
+++ b/trk/src/NfcUtils/writeSignature.js
@@ -11,7 +11,7 @@ async function writeSignature(climbBytes) {
   console.warn('sig', sig);
   const sigBytes = HexUtils.hexToBytes(sig.r + sig.s);
 
-  const sigPageIdx = 12;
+  const sigPageIdx = 15;
   for (let i = 0; i < sigBytes.length; i += 4) {
     console.log("sigBytes.length is ", sigBytes.length);
     const pageIdx = sigPageIdx + i / 4;

--- a/trk/src/Screens/ClimbCreate/index.js
+++ b/trk/src/Screens/ClimbCreate/index.js
@@ -180,7 +180,7 @@ const ClimbInputData = (props) => {
         try {
           await NfcManager.requestTechnology(NfcTech.NfcA);
           await ensurePasswordProtection();
-          const climbBytes = await writeClimb(newClimbId._documentPath._parts[1]);
+          const climbBytes = await writeClimb(newClimbId._documentPath._parts[1], grade);
           let imagesArray = [];
           if (image) {
             const newImageRef = await uploadImage(image.path);
@@ -192,7 +192,9 @@ const ClimbInputData = (props) => {
           await writeSignature(climbBytes);
         }
         catch (ex) {
-          // console.warn("error is hello world");
+          console.error('Error: ', ex);
+          //Errors show up as writeSignature fails sometimes.
+          //NEED TO SOLVE
         }
 
         finally {


### PR DESCRIPTION
- Write grade (French convention) onto the NFC tag on climb creation
- Read grade on NFC read (logged on console for now)
- STILL HAVE SPARE MEMORY (30 spare blocks)
- NEED TO FIX writeSignature (marked in code)