### PR TITLE
[GEN-459] Least completed route calculation fix

### DIFF
--- a/trk/src/Screens/TabScreens/GymAnalytics/GymDaily/Backend/analyticsCalculations.js
+++ b/trk/src/Screens/TabScreens/GymAnalytics/GymDaily/Backend/analyticsCalculations.js
@@ -33,6 +33,10 @@ export const fetchTapsAndCalculateAscents = async (yourClimbs) => {
   let timeFrequencyMap = {};
 
   for (const climb of yourClimbs) {
+    climbFrequencyMap[climb.id] = { count: 0, name: climb.name, id: climb.id, grade: climb.grade };
+  }
+
+  for (const climb of yourClimbs) {
     const tapsSnapshot = await getTapsBySomeField('climb', climb.id);
     if (tapsSnapshot && tapsSnapshot.docs) {
       const taps = tapsSnapshot.docs.map(doc => {
@@ -66,17 +70,34 @@ export const fetchTapsAndCalculateAscents = async (yourClimbs) => {
   let peakTimeString = peakHour ? `${peakHour}:00 - ${parseInt(peakHour) + 1}:00` : '';
 
   // Determine most and least completed climbs
-  let mostCompletedClimb = Object.values(climbFrequencyMap).reduce((a, b) => (a && b && a.count > b.count) ? a : b, null);
-  let leastCompletedClimb = Object.values(climbFrequencyMap).reduce((a, b) => (a && b && a.count < b.count) ? a : b, null);
-
+  let mostCompletedClimbs = [];
+  let leastCompletedClimbs = [];
+  let maxCount = 0;
+  let minCount = Infinity;
+  
+  Object.values(climbFrequencyMap).forEach(climb => {
+    if (climb.count > maxCount) {
+      mostCompletedClimbs = [climb];
+      maxCount = climb.count;
+    } else if (climb.count === maxCount) {
+      mostCompletedClimbs.push(climb);
+    }
+  
+    if (climb.count < minCount) {
+      leastCompletedClimbs = [climb];
+      minCount = climb.count;
+    } else if (climb.count === minCount) {
+      leastCompletedClimbs.push(climb);
+    }
+  });
   // Return the calculated values
   return {
     totalTaps,
     allTaps,
     peakTimeString,
     latestAscentsCount,
-    mostCompletedClimb,
-    leastCompletedClimb
+    mostCompletedClimbs,
+    leastCompletedClimbs
   };
 
 };

--- a/trk/src/Screens/TabScreens/GymAnalytics/GymDaily/Frontend/index.js
+++ b/trk/src/Screens/TabScreens/GymAnalytics/GymDaily/Frontend/index.js
@@ -55,16 +55,16 @@ const GymDaily = () => {
           allTaps,
           peakTimeString,
           latestAscentsCount,
-          mostCompletedClimb,
-          leastCompletedClimb
+          mostCompletedClimbs,
+          leastCompletedClimbs
         } = await fetchTapsAndCalculateAscents(yourClimbs);
 
         setAscents(allTaps);
         setTotalAscents(totalTaps.toString());
         setLatestAscents(latestAscentsCount.toString());
         setPeakTime(peakTimeString);
-        setMostCompleted(mostCompletedClimb || { name: '', id: '', grade: '' });
-        setLeastCompleted(leastCompletedClimb || { name: '', id: '', grade: '' });
+        setMostCompleted(mostCompletedClimbs[0] || { name: '', id: '', grade: '' });
+        setLeastCompleted(leastCompletedClimbs[0] || { name: '', id: '', grade: '' });
       }
     };
 


### PR DESCRIPTION
In gym analytics, fixed the following calculation edge cases
- a climb w/ 0 taps was not taken into account to calculate 'least completed route'
- if multiple climbs had same number of taps and were the least or most completed route, code would break

Now:
- 0 taps is considered 'least' completed
- least and most completed route is now an array that can contain multiple routes, and only the first climb in array is displayed on gym analytics