### PR TITLE
[GEN-203] Fixed setter tap creation (including redux cache)

### DIFF
--- a/trk/src/Actions/tapActions.js
+++ b/trk/src/Actions/tapActions.js
@@ -2,15 +2,16 @@ import ClimbsApi from '../api/ClimbsApi';
 import TapsApi from '../api/TapsApi';
 import Toast from 'react-native-toast-message';
 
-export const processClimbId = (climbId, currentUser) => {
+export const processClimbId = (climbId, currentUser, role) => {
     return new Promise(async(resolve, reject) => {
       // To process the climbId
       console.log('Processing climbId:', climbId);
-      console.log('Current User: ', currentUser)
+      console.log('Current User: ', currentUser);
+      console.log('Current Role: ', role);
       try {
         const climbDataResult = await ClimbsApi().getClimb(climbId);
         if (climbDataResult && climbDataResult._data) {
-          if (currentUser.uid !== climbDataResult._data.setter) {
+          if (currentUser.uid !== climbDataResult._data.setter && role !== "setter") { //case for climbers (tap should log), else should not
             const { addTap } = TapsApi();
             const tap = {
               climb: climbId,
@@ -32,7 +33,7 @@ export const processClimbId = (climbId, currentUser) => {
             });
           } else {
             // Handle the case where currentUser.uid === climbDataResult._data.setter
-            console.log('The Setter is the user. Tap was not added');
+            console.log('The Setter is the user or this a Setter Account. Tap was not added');
             reject(new Error('User cannot log their own climb')); 
             Toast.show({
                 type: 'success',
@@ -47,7 +48,7 @@ export const processClimbId = (climbId, currentUser) => {
             });
         }
       } catch (error) {
-        console.error('Error processing climbId:', error);
+        //console.error('Error processing climbId:', error);
         reject(new Error('Firebase error'));
         Toast.show({
             type: 'error',
@@ -57,15 +58,15 @@ export const processClimbId = (climbId, currentUser) => {
     });
 };
 
-export const addClimb = (climbId, currentUser) => {
+export const addClimb = (climbId, currentUser, role) => {
     return {
       type: 'ADD_CLIMB',
-      payload: {climbId, currentUser},
+      payload: {climbId, currentUser, role},
       meta: {
         offline: {
-          effect: { climbId: climbId, currentUser: currentUser },
-          commit: { type: 'ADD_CLIMB_COMMIT', meta: {climbId, currentUser} },
-          rollback: { type: 'ADD_CLIMB_ROLLBACK', meta: {climbId, currentUser} }
+          effect: { climbId: climbId, currentUser: currentUser, role: role},
+          commit: { type: 'ADD_CLIMB_COMMIT', meta: {climbId, currentUser, role} },
+          rollback: { type: 'ADD_CLIMB_ROLLBACK', meta: {climbId, currentUser, role} }
         }
       }
     };

--- a/trk/src/Reducers/tapReducer.js
+++ b/trk/src/Reducers/tapReducer.js
@@ -1,6 +1,7 @@
 const initialState = {
     climbIDs: [],
     currentUsers: [],
+    currentRoles: [],
     // other state properties if needed.
     // need to build this out if more data is stored on the NFC tag.
   };
@@ -14,24 +15,29 @@ switch (action.type) {
     // Climb successfully processed.
     console.log('Climb Processed: ', action.meta.climbId);
     console.log('User Processed: ', action.meta.currentUser);
+    console.log('Role Processed: ', action.meta.role);
     return {
         ...state,
         climbIDs: state.climbIDs.filter(id => id !== action.meta.climbId),
         currentUsers: state.currentUsers.filter(id => id !== action.meta.currentUser),
+        currentRoles: state.currentRoles.filter(id => id !== action.meta.role),
     };
     case 'ADD_CLIMB':
     // Climb read from NFC tag.
     console.log('Added Climb: ', action.payload.climbId); // Log the added climb ID
     console.log('Added User: ', action.payload.currentUser); // Log the added currentUser
+    console.log('Added Role: ', action.payload.role); // Log the added role
     return {
         ...state,
         climbIDs: [...state.climbIDs, action.payload.climbId],
         currentUsers: [...state.currentUsers, action.payload.currentUser],
+        currentRoles: [...state.currentRoles, action.payload.role],
     };
     case 'ADD_CLIMB_ROLLBACK':
     // Failed to process climb ID.
-    console.error('Failed to process climb ID:', action.meta.climbId);
-    console.error('Failed to process current User:', action.meta.currentUser);
+    console.log('Failed to process climb ID:', action.meta.climbId);
+    console.log('Failed to process current User:', action.meta.currentUser);
+    console.log('Failed to process current role:', action.meta.role);
     return state;
     default:
     return state;

--- a/trk/src/Screens/NavScreens/ClimbDetail/Backend/ClimbDetailLogic.js
+++ b/trk/src/Screens/NavScreens/ClimbDetail/Backend/ClimbDetailLogic.js
@@ -4,14 +4,14 @@ import storage from '@react-native-firebase/storage';
 import { Alert } from 'react-native';
 import { View, Text, StyleSheet, ScrollView, SafeAreaView, Image, TextInput, Button, TouchableWithoutFeedback, Keyboard, Share, TouchableOpacity } from 'react-native';
 
-export const fetchClimbData = async (climbId, currentUser) => {
+export const fetchClimbData = async (climbId, currentUser, role) => {
   try {
     const climbDataResult = await ClimbsApi().getClimb(climbId);
     let tapId = null;
     if (climbDataResult && climbDataResult._data) {
       //setClimbData(climbDataResult._data);
       console.log("Fetched climb data:", climbDataResult._data);
-      if (currentUser.uid !== climbDataResult._data.setter) {
+      if (currentUser.uid !== climbDataResult._data.setter && role !== "setter") { //case for climbers (tap should log), else should not
         const { addTap } = TapsApi();
         const tap = {
           climb: climbId,
@@ -23,6 +23,7 @@ export const fetchClimbData = async (climbId, currentUser) => {
           witness2: '',
         };
         const documentReference = await addTap(tap);
+        console.log('Tap created!');
         //setTapId(documentReference.id); // Set tapId only when navigating from home
         tapId = documentReference.id;
       }
@@ -31,7 +32,7 @@ export const fetchClimbData = async (climbId, currentUser) => {
       throw new Error("Climb data not found.");
     }
   } catch (error) {
-    console.error('Error fetching climb data:', error);
+    //console.error('Error fetching climb data:', error);
     throw new Error("Failed to load climb data.");
   }
 };

--- a/trk/src/Screens/NavScreens/ClimbDetail/Frontend/index.js
+++ b/trk/src/Screens/NavScreens/ClimbDetail/Frontend/index.js
@@ -13,7 +13,7 @@ import { fetchClimbData, getTapDetails, loadImageUrl, updateTap, archiveTap, han
 function ClimbDetail(props) {
   console.log('[TEST] ClimbDetail called');
 
-  const { climbId, isFromHome } = props.route.params;
+  const { climbId, isFromHome} = props.route.params;
   const [climbData, setClimbData] = useState(props.route.params.climbData || null);
   const [isLoading, setIsLoading] = useState(isFromHome);
   const [climbImageUrl, setClimbImageUrl] = useState(null);
@@ -32,16 +32,16 @@ function ClimbDetail(props) {
     if (isFromHome && climbId) {
       async function fetchData() {
         try {
-          const { climbData, tapId } = await fetchClimbData(climbId, currentUser);
+          const { climbData, tapId } = await fetchClimbData(climbId, currentUser, role);
           setClimbData(climbData);
           if (tapId) {
             setTapId(tapId);
           }
         } catch (error) {
-          console.error('Error:', error);
+          console.log('Error caught:', error);
           Alert.alert(
             "Error",
-            error,
+            error.message,
             [{ text: "OK", onPress: () => navigation.goBack() }],
             { cancelable: false }
           );

--- a/trk/src/Screens/TabScreens/Record/Backend/logic.js
+++ b/trk/src/Screens/TabScreens/Record/Backend/logic.js
@@ -22,7 +22,7 @@ export const useHomeScreenLogic = (props) => {
     const [hasNfc, setHasNfc] = React.useState(null);
     const [enabled, setEnabled] = React.useState(null);
     // user check
-    const { currentUser } = useContext(AuthContext);
+    const { currentUser,role} = useContext(AuthContext);
 
     const dispatch = useDispatch();
 
@@ -32,9 +32,9 @@ export const useHomeScreenLogic = (props) => {
             console.log("Is connected?", state.isConnected);
             if (state.isConnected) {
                 console.log('Navigating');
-                navigation.navigate('Detail', { climbId: climbId[0], isFromHome: true });
+                navigation.navigate('Detail', { climbId: climbId[0], isFromHome: true});
             } else {
-                dispatch(addClimb(climbId[0], currentUser));
+                dispatch(addClimb(climbId[0], currentUser, role));
                 Alert.alert('Offline Action', 'Your action is saved and will be processed when you\'re online.', [{ text: 'OK' }]);
             }
         });
@@ -43,6 +43,8 @@ export const useHomeScreenLogic = (props) => {
 
     useEffect(() => {
         console.log('[TEST] HomeScreen useEffect called');
+        //console.log('User role testing......');
+        //console.log(role);
         async function checkNfc() {
             const supported = await NfcManager.isSupported();
             if (supported) {
@@ -77,7 +79,7 @@ export const useHomeScreenLogic = (props) => {
             }
         } catch (ex) {
             if (isReading) {
-                Alert.alert('Info', 'Climb tagging cancelled.', [{ text: 'OK' }]);
+                Alert.alert('Action', 'Climb tagging cancelled.', [{ text: 'OK' }]);
             } else {
                 Alert.alert('Error', ex.message || 'Climb not found!', [{ text: 'OK' }]);
             }

--- a/trk/src/reduxStore.js
+++ b/trk/src/reduxStore.js
@@ -6,7 +6,7 @@ import tapReducer from './Reducers/tapReducer';
 import {processClimbId} from './Actions/tapActions';
 
 const effect = (effect, _action) => {
-    return processClimbId(effect.climbId, effect.currentUser);
+    return processClimbId(effect.climbId, effect.currentUser, effect.role);
 };
 
 const discard = (error, action, retries) => {


### PR DESCRIPTION
- Accounted for role in tap creation (simply passing the variable for Climb Detail)
- For the cached taps, I stored the role and processed it alongside in the Redux Store
- Minor bug fix for the Error shown when there is no climb stored on the NFC tag (needed to put error.message instead of error)
- Altered some console.erorr calls to console.log for simplicity
- The only changes made in logic are in fetchClimbData (ClimbDetailLogic.js) and processClimbId (tapActions.js)