### PR TITLE
[GEN-568] timestamp fix v2

### DIFF
--- a/trk/src/Actions/tapActions.js
+++ b/trk/src/Actions/tapActions.js
@@ -16,7 +16,8 @@ export const processClimbId = (climbId, currentUser, role) => {
             const tap = {
               climb: climbId,
               user: currentUser.uid,
-              timestamp: moment().tz('America/New_York'),
+              // timestamp: moment().tz('America/New_York'),
+              timestamp: new Date(),
               completion: 0,
               attempts: '',
               witness1: '',

--- a/trk/src/Screens/NavScreens/ClimbDetail/Backend/ClimbDetailLogic.js
+++ b/trk/src/Screens/NavScreens/ClimbDetail/Backend/ClimbDetailLogic.js
@@ -17,7 +17,8 @@ export const fetchClimbData = async (climbId, currentUser, role) => {
         const tap = {
           climb: climbId,
           user: currentUser.uid,
-          timestamp: moment().tz('America/New_York'),
+          // timestamp: moment().tz('America/New_York'),
+          timestamp: new Date(),
           completion: 0,
           attempts: '',
           witness1: '',


### PR DESCRIPTION
Replaced `ClimbDetailLogic.js` and `tapActions.js`'s timestamp date format with `new Date()`.

<img width="484" alt="Screenshot 2024-01-17 at 12 14 21 pm" src="https://github.com/nagimonyc/trk-app/assets/66965648/902c6ef6-9c2e-4ec3-9a92-d8ca343c3ac2">
<img width="547" alt="Screenshot 2024-01-17 at 12 14 33 pm" src="https://github.com/nagimonyc/trk-app/assets/66965648/7bfbe6ee-1bb3-4118-b200-a4301b32b460">
