### PR TITLE
Fix for Session Timestamp

### DIFF
--- a/trk/src/Components/SessionTapHistory.js
+++ b/trk/src/Components/SessionTapHistory.js
@@ -17,24 +17,28 @@ const formatTimestamp = (timestamp) => {
 
 
 const convertTimestampToDate = (timestamp) => {
-    if (!timestamp || typeof timestamp.seconds !== 'number') {
+    console.log("Received timestamp:", timestamp);
+    if (!timestamp || typeof timestamp.seconds !== 'number' || typeof timestamp.nanoseconds !== 'number') {
         console.error('Invalid or missing timestamp:', timestamp);
-        return null; // Or return a default date, as per your logic
+        return null; // Return null or a default date, as per your logic
     }
-    return new Date(timestamp.seconds * 1000 + timestamp.nanoseconds / 1000000);
+    // Convert to milliseconds and create a new Date object
+    return new Date(timestamp.seconds * 1000 + Math.round(timestamp.nanoseconds / 1000000));
 };
+
 
 const groupClimbsByTimestamp = (climbs) => {
     const grouped = {};
     climbs.forEach(climb => {
-        const dateObject = convertTimestampToDate(climb.timestamp);
+        const dateObject = convertTimestampToDate(climb.tapTimestamp);
+        console.log('Date Object:', dateObject);
         if (!dateObject) {
             // Handle the error or skip this climb
             console.error('Skipping climb due to invalid date:', climb);
             return;
         }
         // Convert the timestamp to a standard JavaScript Date object
-        const date = moment(convertTimestampToDate(climb.timestamp)).tz('America/New_York');
+        const date = moment(dateObject).tz('America/New_York');
         
         // Round down the timestamp to the nearest 4 hours
         const hours = date.hours();
@@ -42,7 +46,8 @@ const groupClimbsByTimestamp = (climbs) => {
         const roundedDate = date.clone().hours(roundedHours).minutes(0).seconds(0).milliseconds(0);
 
         const key = roundedDate.format('YYYY-MM-DD HH:mm'); // Formatted key
-        //console.log(key); // Debugging
+        console.log(key); // Debugging
+        //console.log(climb.tapId);
         if (!grouped[key]) {
             grouped[key] = [];
         }
@@ -54,6 +59,7 @@ const groupClimbsByTimestamp = (climbs) => {
 const SessionTapHistory = (props) => {
     console.log('[TEST] SessionTapHistory called');
     // Group climbs by timestamp
+    console.log(props.climbsHistory);
     const groupedClimbs = groupClimbsByTimestamp(props.climbsHistory);
     return (
         <ScrollView>
@@ -64,7 +70,7 @@ const SessionTapHistory = (props) => {
                     </Text>
                     <ListHistory
                         data={climbs}
-                        renderItem={(item) => <ClimbItem climb={item} tapId={item.tapId} tapTimestamp={item.timestamp} fromHome={props.fromHome} />}
+                        renderItem={(item) => <ClimbItem climb={item} tapId={item.tapId} tapTimestamp={item.tapTimestamp} fromHome={props.fromHome} />}
                         keyExtractor={(item, index) => index.toString()}
                     />
                 </View>

--- a/trk/src/Screens/TabScreens/Profile/Backend/ClimberProfile.js
+++ b/trk/src/Screens/TabScreens/Profile/Backend/ClimberProfile.js
@@ -41,7 +41,7 @@ const ClimberProfile = ({ navigation }) => {
             // Combine climb details with tap data
             const newClimbsHistory = climbsSnapshots.map((climbSnapshot, index) => {
                 if (!climbSnapshot.exists) return null;
-                return { ...climbSnapshot.data(), tapId: filteredTaps[index].id };
+                return { ...climbSnapshot.data(), tapId: filteredTaps[index].id, tapTimestamp: filteredTaps[index].timestamp};
             }).filter(climb => climb !== null && (climb.archived === undefined || climb.archived === false));
     
             setClimbsHistory(newClimbsHistory);


### PR DESCRIPTION
- The timestamp being used for sessions was erroneously the climb timestamp (only a single timestamp variable was being used in the climb object, so I had picked it).
- Now the timestamp correctly reflects the tap timestamp.