### PR TITLE
[GEN-588] Message condition FTU v returning user logic

### DIFF
--- a/trk/assets/tagMessages.json
+++ b/trk/assets/tagMessages.json
@@ -1,25 +1,23 @@
 {
-  "FTUFirstClimb": [
+  "FTU": [
       "Completed a climb 🧗‍♂️  Tap below to save it "
   ],
-  "FTUNotFirstClimb": [
-      "Keep climbing, keep tapping 👊",
-      "Every climb deserves a tap  🌟🌟"
-  ],
-  "ReturningUserFirstClimbOfDay": [
+  "FirstClimbOfDay": [
       "Ready for more 💪  Tap your first climb!",
       "Here for another session? That's dedication 🏆"
   ],
-  "ReturningUserFirstClimbOfAnotherSession": [
+  "FirstClimbOfAnotherSession": [
       "Nice to see you again 🤟",
       "Back again so soon!",
       "Fancy seeing you here  🚀🚀",
       "Twice in 1 day  🔄🔄🔄  you know what to do"
   ],
-  "ReturningUserNotFirstClimb": [
+  "NotFirstClimb": [
       "Another climb, another tap 👌",
+      "Keep climbing, keep tapping 👊",
       "Make every climb count  🔥🔥🔥",
       "Keep up the momentum  🦌🦌🦌",
+      "Every climb deserves a tap  🌟🌟",
       "Every tap counts ⚡️"
   ]
 }

--- a/trk/src/Screens/TabScreens/Record/Backend/logic.js
+++ b/trk/src/Screens/TabScreens/Record/Backend/logic.js
@@ -12,6 +12,7 @@ import { addClimb } from '../../../../Actions/tapActions';
 import tapMessage from '../../../../../assets/tagMessages.json'
 
 import NetInfo from '@react-native-community/netinfo';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 export const useHomeScreenLogic = (props) => {
     // Animation
@@ -31,11 +32,15 @@ export const useHomeScreenLogic = (props) => {
     const dispatch = useDispatch();
 
     //Next PR these will actually be calculated rather than hardcoded (set the true value to the option with the most messages in JSON file)
-    let isFirstTimeUser = false;
-    let isFTUNotFirstClimb = false;
-    let isReturningUserFirstClimbOfDay = false;
-    let isReturningUserFirstClimbOfAnotherSession = true;
-    let isReturningUserNotFirstClimb = false;
+    
+    
+    const [isFirstTimeUser, setIsFirstTimeUser] = useState(false);
+    // const [isFirstClimbOfDay] = useState(false);
+    let isFirstClimbOfDay = false;
+    // const [isFirstClimbOfAnotherSession] = useState(false)
+    let isFirstClimbOfAnotherSession = true;
+    // const [isNotFirstClimb] = useState(false)
+    let isNotFirstClimb = false;
 
 
     const [selectedMessage, setSelectedMessage] = useState('');
@@ -45,24 +50,48 @@ export const useHomeScreenLogic = (props) => {
         return Math.floor(Math.random() * array.length);
     }
 
+    //This sets a flag in local storage (avaible without wifi) to define if someone is FTU -> we can reuse this elsewhere if FTU/returning user needs to be checked
+    const checkFirstTimeUser = async () => {
+        try {
+          const isFirstTime = await AsyncStorage.getItem('isFirstTimeUser');
+          if (isFirstTime === null) {
+            // It's the first time, set the flag
+            await AsyncStorage.setItem('isFirstTimeUser', 'true');
+            setIsFirstTimeUser(true); // Set state to true
+          } else {
+            setIsFirstTimeUser(false); // Set state to false if not first time
+          }
+        } catch (error) {
+          console.error('Error checking first-time user status:', error);
+          setIsFirstTimeUser(false); // Default to false in case of error
+        }
+      };
+  
+      useFocusEffect(
+        useCallback(() => {
+            checkFirstTimeUser();
+        }, [])
+    );
     const selectRandomMessage = useCallback(() => {
         let message;
         if (isFirstTimeUser) {
-            message = tapMessage.FTUFirstClimb[randomIndex(tapMessage.FTUFirstClimb)];
-        } else if (isFTUNotFirstClimb) {
-            message = tapMessage.FTUNotFirstClimb[randomIndex(tapMessage.FTUNotFirstClimb)];
-        } else if (isReturningUserFirstClimbOfDay) {
-            message = tapMessage.ReturningUserFirstClimbOfDay[randomIndex(tapMessage.ReturningUserFirstClimbOfDay)];
-        } else if (isReturningUserFirstClimbOfAnotherSession) {
-            message = tapMessage.ReturningUserFirstClimbOfAnotherSession[randomIndex(tapMessage.ReturningUserFirstClimbOfAnotherSession)];
-        } else if (isReturningUserNotFirstClimb) {
-            message = tapMessage.ReturningUserNotFirstClimb[randomIndex(tapMessage.ReturningUserNotFirstClimb)];
+            message = tapMessage.FTU[randomIndex(tapMessage.FTU)];
+        } else if (isFirstClimbOfDay) {
+            message = tapMessage.FirstClimbOfDay[randomIndex(tapMessage.FirstClimbOfDay)];
+        } else if (isFirstClimbOfAnotherSession) {
+            message = tapMessage.FirstClimbOfAnotherSession[randomIndex(tapMessage.FirstClimbOfAnotherSession)];
+        } else if (isNotFirstClimb) {
+            message = tapMessage.NotFirstClimb[randomIndex(tapMessage.NotFirstClimb)];
         } else {
             // Default message or other logic
             message = "Completed a climb? 🎉🎉🎉  Tap below to save your achievement";
         }
         setSelectedMessage(message);
-    }, [isFirstTimeUser, isFTUNotFirstClimb, isReturningUserFirstClimbOfDay]);
+    }, [isFirstTimeUser, isFirstClimbOfDay]);
+
+    useEffect(() => {
+        selectRandomMessage();
+    }, [isFirstTimeUser]);
 
     useFocusEffect(selectRandomMessage);
   

--- a/trk/src/Screens/TabScreens/Record/Backend/logic.js
+++ b/trk/src/Screens/TabScreens/Record/Backend/logic.js
@@ -59,9 +59,9 @@ export const useHomeScreenLogic = (props) => {
     // const [isFirstClimbOfDay] = useState(false);
     let isFirstClimbOfDay = false;
     // const [isFirstClimbOfAnotherSession] = useState(false)
-    let isFirstClimbOfAnotherSession = true;
+    let isFirstClimbOfAnotherSession = false;
     // const [isNotFirstClimb] = useState(false)
-    let isNotFirstClimb = false;
+    let isNotFirstClimb = true;
 
 
     const [selectedMessage, setSelectedMessage] = useState('');


### PR DESCRIPTION
### **Overview**
- added a flag in local storage that allows to check FTU v returning user
- use this flag to set the FTU state
- removed one of the conditions of returning user and combined the messages in JSON file (reason - messaging was almost identical in both conditions)
- In next PR, will do the rest of the set state for the multiple conditions of returning user