### PR TITLE
Session Revamp (Top-down Approach)

### DIFF
--- a/trk/src/Screens/TabScreens/Record/Backend/logic.js
+++ b/trk/src/Screens/TabScreens/Record/Backend/logic.js
@@ -400,11 +400,16 @@ export const useHomeScreenLogic = (props) => {
                         </View>
 
                         <ClimbItem climb={climb} tapId={tapId} tapTimestamp={timeStampFormatting(tapObj.timestamp)} fromHome={true}/>
+                        <View style={{display: 'flex', flexDirection: 'column', paddingVertical: 5}}>
+                        <View style={{ alignSelf: 'center' }}>
+                            {tapObj.isSessionStart && <Text style={{ backgroundColor: 'white', textAlign: 'center', paddingHorizontal: 5, paddingVertical: 3, fontSize: 13, borderRadius: 3, color: 'black'}}>First Tap in Session!</Text>}
+                        </View>
                         <TouchableOpacity style={styles.navigate}
                             onPress={() => navigation.navigate('ProfileTab')}>
                            <Text style={styles.buttonText}>Check it out</Text>
                            <RightArrow style={{ width: '100%', height: '100%' }} />
                         </TouchableOpacity>
+                        </View>
 
                         </Animated.View>
                     )}

--- a/trk/src/Screens/TabScreens/Record/Backend/logic.js
+++ b/trk/src/Screens/TabScreens/Record/Backend/logic.js
@@ -400,6 +400,7 @@ export const useHomeScreenLogic = (props) => {
                         </View>
 
                         <ClimbItem climb={climb} tapId={tapId} tapTimestamp={timeStampFormatting(tapObj.timestamp)} fromHome={true}/>
+                        
                         <View style={{display: 'flex', flexDirection: 'column', paddingVertical: 5}}>
                         <View style={{ alignSelf: 'center' }}>
                             {tapObj.isSessionStart && <Text style={{ backgroundColor: 'white', textAlign: 'center', paddingHorizontal: 5, paddingVertical: 3, fontSize: 13, borderRadius: 3, color: 'black'}}>First Tap in Session!</Text>}
@@ -432,6 +433,8 @@ export const useHomeScreenLogic = (props) => {
         androidPromptRef,
     };
 };
+//Have leveraged the abilities of the new session mock object
+//@redpepper-nag
 
 const styles = StyleSheet.create({
     center: {

--- a/trk/src/api/TapsApi.js
+++ b/trk/src/api/TapsApi.js
@@ -104,6 +104,8 @@ function TapsApi() {
                 .get();
     }
 
+
+    //To get the last Tap made by a user
     function getLastUserTap(userId) {
         console.log('User ID: ', userId);
         return ref
@@ -115,6 +117,7 @@ function TapsApi() {
             .get();
     }
 
+    //To get all the taps in the current session
     function getActiveSessionTaps(userId) {
         console.log('User ID: ', userId);
         console.log('Fetching Active Session Climbs....');
@@ -124,6 +127,7 @@ function TapsApi() {
             .orderBy("expiryTime", "desc").get();
     }
 
+    //To get the starting points of the last 5 expired sessions
     function getRecentFiveSessions(userId) {
         console.log('User ID: ', userId);
         console.log('Fetching 5 Session Start Climbs....');
@@ -136,17 +140,7 @@ function TapsApi() {
             .get();
     }
 
-    function getTapsAfterSessionStart(userId) {
-        console.log('User ID: ', userId);
-        console.log('Fetching 5 Session Start Climbs....');
-        return ref
-            .where('user', '==', userId)
-            .where('isSessionStart', '==', true)
-            .orderBy("expiryTime", "desc")
-            .limit(5)
-            .get();
-    }
-
+    //To get all expired taps to build Expired sessions
     function getExpiredTaps(userId) {
         console.log('User ID: ', userId);
         console.log('Fetching Expired Climbs....');
@@ -156,8 +150,6 @@ function TapsApi() {
             .orderBy("expiryTime", "desc")
             .get();
     }
-    
-    
 
     return {
         addTap,

--- a/trk/src/api/TapsApi.js
+++ b/trk/src/api/TapsApi.js
@@ -123,6 +123,40 @@ function TapsApi() {
             .where("expiryTime", ">", firebase.firestore.Timestamp.now())
             .orderBy("expiryTime", "desc").get();
     }
+
+    function getRecentFiveSessions(userId) {
+        console.log('User ID: ', userId);
+        console.log('Fetching 5 Session Start Climbs....');
+        return ref
+            .where('user', '==', userId)
+            .where('isSessionStart', '==', true)
+            .where("expiryTime", '<=', firebase.firestore.Timestamp.now())
+            .orderBy("expiryTime", "desc")
+            .limit(5)
+            .get();
+    }
+
+    function getTapsAfterSessionStart(userId) {
+        console.log('User ID: ', userId);
+        console.log('Fetching 5 Session Start Climbs....');
+        return ref
+            .where('user', '==', userId)
+            .where('isSessionStart', '==', true)
+            .orderBy("expiryTime", "desc")
+            .limit(5)
+            .get();
+    }
+
+    function getExpiredTaps(userId) {
+        console.log('User ID: ', userId);
+        console.log('Fetching Expired Climbs....');
+        return ref
+            .where('user', '==', userId)
+            .where("expiryTime", '<=', firebase.firestore.Timestamp.now())
+            .orderBy("expiryTime", "desc")
+            .get();
+    }
+    
     
 
     return {
@@ -137,6 +171,8 @@ function TapsApi() {
         getTapsByClimbAndDate, 
         getLastUserTap,
         getActiveSessionTaps,
+        getRecentFiveSessions,
+        getExpiredTaps,
     };
 }
 


### PR DESCRIPTION
- Sessions are now calculated using isSession start
- Active session climbs can be fetched with a single query based on timestamp (less time, no heavy processing)
- Expired sessions are paginated (5 for now, will be dynamically reloading 5 on bottom hit every time- NEXT PR)
- Climbs History is irrelevant now (all calculations can be done with sessions), will remove in next PR
- Have shown how the new mock session objects can be used @redpepper-nag (Record/Backend/logic.js)- First Tap in Session