### PR TITLE
Session Pagination Implemented

### DIFF
--- a/trk/src/Components/SessionTapHistory.js
+++ b/trk/src/Components/SessionTapHistory.js
@@ -72,7 +72,7 @@ const SessionTapHistory = (props) => {
             {Object.entries(groupedClimbs).reverse().map(([key, climbs]) => (
                 <View key={key}>
                     <View style={{paddingVertical: 5, paddingHorizontal: 20}}>
-                        {(props.isCurrent && climbs) && (
+                        {(props.isCurrent && climbs && climbs.length > 0) && (
                             <View style={{flexDirection: 'row', justifyContent: 'space-between', width: '100%', alignItems: 'center'}}>
                                 <Text style={{color: 'black', fontWeight: 'bold'}}>Climbs in Current Session</Text>
                                 <View style={{padding: 5, borderRadius: 5, borderWidth: 1, borderColor: '#fe8100'}}>
@@ -80,7 +80,7 @@ const SessionTapHistory = (props) => {
                                 </View>
                             </View>
                         )}
-                        {(props.isCurrent && !climbs) && (
+                        {(props.isCurrent && climbs && climbs.length == 0) && (
                             <View style={{flexDirection: 'row', justifyContent: 'space-between', width: '100%', alignItems: 'center'}}>
                                 <Text style={{color: 'black', fontWeight: 'bold'}}>No active session</Text>
                                 <View style={{padding: 5, borderRadius: 5, borderWidth: 1, borderColor: '#fe8100'}}>

--- a/trk/src/api/TapsApi.js
+++ b/trk/src/api/TapsApi.js
@@ -127,18 +127,25 @@ function TapsApi() {
             .orderBy("expiryTime", "desc").get();
     }
 
-    //To get the starting points of the last 5 expired sessions
-    function getRecentFiveSessions(userId) {
+    // To get the starting points of the last sessions with pagination
+    function getRecentFiveSessions(userId, startAfterDoc = null) {
         console.log('User ID: ', userId);
-        console.log('Fetching 5 Session Start Climbs....');
-        return ref
+        console.log('Fetching Session Start Climbs with Pagination....');
+        let query = ref
             .where('user', '==', userId)
             .where('isSessionStart', '==', true)
             .where("expiryTime", '<=', firebase.firestore.Timestamp.now())
             .orderBy("expiryTime", "desc")
-            .limit(5)
-            .get();
+            .limit(5);
+
+        if (startAfterDoc) {
+            console.log('Starting after: ', startAfterDoc);
+            query = query.startAfter(startAfterDoc);
+        }
+
+        return query.get();
     }
+
 
     //To get all expired taps to build Expired sessions
     function getExpiredTaps(userId) {
@@ -148,6 +155,18 @@ function TapsApi() {
             .where('user', '==', userId)
             .where("expiryTime", '<=', firebase.firestore.Timestamp.now())
             .orderBy("expiryTime", "desc")
+            .get();
+    }
+
+    //To get all sessions quicker (display count)
+    function getTotalSessionCount(userId) {
+        console.log('User ID: ', userId);
+        console.log('Fetching Expired Climbs....');
+        return ref
+            .where('user', '==', userId)
+            .where('isSessionStart', '==', true)
+            .where('archived', '==', false)
+            .count()
             .get();
     }
 
@@ -165,6 +184,7 @@ function TapsApi() {
         getActiveSessionTaps,
         getRecentFiveSessions,
         getExpiredTaps,
+        getTotalSessionCount,
     };
 }
 


### PR DESCRIPTION
- Paginated sessions (5 load initially)
- As the user reaches the end of the screen, 5 more keep loading.
- All climbs are loaded initially, but this avoids passing through the entire loop when loading sessions every time.
- The new sessions are appended to the bottom of SessionTapHistory, for smoother loading (not reset)