### PR TITLE
[GEN-536] Editing capabilities for sessions

### DIFF
--- a/trk/src/Components/ClimbItem.js
+++ b/trk/src/Components/ClimbItem.js
@@ -13,7 +13,7 @@ const RightArrow = () => (
   </Svg>
 );
 
-const ClimbItem = ({climb, tapId, fromHome = false, tapTimestamp, isHighlighted = false}) => {
+const ClimbItem = ({climb, tapId, fromHome = false, tapTimestamp, isHighlighted = false, sessionPick = false, tapIdRef = null, setSelectedTapId = null}) => {
     console.log('[TEST] ClimbItem called');
     const [imageURL, setImageURL] = useState(null);
     const navigation = useNavigation();
@@ -32,6 +32,17 @@ const ClimbItem = ({climb, tapId, fromHome = false, tapTimestamp, isHighlighted 
         fetchImageURL();
     }, []);
 
+
+    //To hanndle selection of the item within Edit Session (change in useRef variable)
+    const handleSelection = (id) => {
+        if (tapIdRef === null) {
+            console.log('No selection made!');
+        } else {
+            tapIdRef.current = id;
+            setSelectedTapId(tapIdRef.current);
+            console.log('Selection made: ', tapIdRef.current);
+        }
+    }
 
     const navigateToDetail = async () => {
         try {
@@ -63,8 +74,19 @@ const ClimbItem = ({climb, tapId, fromHome = false, tapTimestamp, isHighlighted 
                 </ListItemContainer>
             </View>
         );
-    }
-    else {
+    } else if (sessionPick) {
+        //Different formatting for SessionDetailLook
+        return (
+            <TouchableOpacity onPress={() => {handleSelection(climb.tapId)}}>
+                <ListItemContainer dotStyle={styles.climbDot} grade={climb.grade} isHighlighted={isHighlighted}> 
+                    <Text style={styles.climbName}>{climb.name}</Text>
+                    <View style={styles.setterDot}>
+                        <Text style={{color: 'black', paddingRight: 10}}>{tapTimestamp}</Text>
+                    </View>
+                </ListItemContainer>
+            </TouchableOpacity>
+        );
+    } else {
         //Added the timestamp to the Profile ClimbItem for better understanding of which tap was logged. Current pattern makes it difficult to find the most recent tap on navigation.
         //Highlighted the first climb of the active session (for clarity on which climb was logged)
         return (

--- a/trk/src/Components/Edit_Session.js
+++ b/trk/src/Components/Edit_Session.js
@@ -1,0 +1,373 @@
+import React, { useState, useContext, useEffect, useRef } from "react";
+import { View, Text, Button, TextInput, StyleSheet, Alert, TouchableOpacity, ScrollView, SafeAreaView } from "react-native";
+import firestore from '@react-native-firebase/firestore';
+import { AuthContext } from "../Utils/AuthContext";
+import { useNavigation } from '@react-navigation/native';
+import storage from '@react-native-firebase/storage';
+import ListItemSessions from "./ListItemSessions";
+import { Image } from "react-native";
+import ClimbItem from "./ClimbItem";
+import ListHistory from "./ListHistory";
+import { FlatList } from "react-native-gesture-handler";
+import { ActivityIndicator } from "react-native-paper";
+import {Modal} from "react-native-paper";
+import Icon from 'react-native-vector-icons/MaterialIcons'; // Or any other icon family you prefer
+import TapsApi from "../api/TapsApi";
+import ImagePicker from 'react-native-image-crop-picker';
+
+const EditSession = ({route}) => {
+  const navigation = useNavigation();
+  let data = route.params.data;
+  const title = route.params.title;
+  //data[0].images = [{path: 'climb photos/the_crag.png'},{path: 'climb photos/the_crag.png'},{path: 'climb photos/the_crag.png'},{path: 'climb photos/the_crag.png'}];
+  
+  //Setting selected tapId
+  const tapIdRef = useRef(null);
+
+  let initallySelected = null;
+  let initialText = null;
+  console.log(data);
+  //Selected Item Set
+  if (data.length>0) {
+    const selectedData = data.filter(obj => obj.isSelected == true);
+    console.log('The selected Data is: ', selectedData);
+    if (selectedData.length == 0) {
+        tapIdRef.current = data[0].tapId;
+        initallySelected = data[0].tapId;
+        console.log('Initially selected value is: ', tapIdRef.current);
+    } else {
+        tapIdRef.current = selectedData[0].tapId;
+        initallySelected = selectedData[0].tapId;
+        console.log('Initially selected value is: ', tapIdRef.current);
+    }
+    if (data[data.length-1].sessionTitle === undefined || (data[data.length-1].sessionTitle && data[data.length-1].sessionTitle === '')) {
+        initialText = 'Session on '+title[1];
+    }
+    else {
+        initialText = data[data.length-1].sessionTitle;
+    }
+    console.log('Initial session text: ', initialText);
+  }
+  const [selectedTapId, setSelectedTapId] = useState(tapIdRef.current);
+  const [sessionTitle, setSessionTitle] = useState(initialText);
+
+  const [climbImageUrl, setClimbImageUrl] = useState(null);
+  const [initialImagePath, setInitialImagePath] = useState('');
+  const { currentUser } = useContext(AuthContext);
+
+  const [selectedImage, setSelectedImage] = useState(null);
+  const [modalVisible, setModalVisible] = useState(false);
+  
+  const handleImagePress = (imageUrl) => {
+    setSelectedImage(imageUrl);
+    setModalVisible(true);
+  };
+
+    //To fetch the climb image of the latest climb
+    const loadImageUrl = async (imagePath) => {
+        try {
+          const url = await storage().ref(imagePath).getDownloadURL();
+          return url;
+        } catch (error) {
+          console.error("Error getting image URL: ", error);
+          throw error;
+        }
+    };
+    
+    
+    //Time stamp formatting like Home Page for clarity (Altered ClimbItem to match)
+    const timeStampFormatting = (timestamp) => {
+        let tempTimestamp = null;
+        if (timestamp.toDate) { // Convert Firebase Timestamp to JavaScript Date
+            tempTimestamp = timestamp.toDate().toLocaleTimeString('en-US', {
+              hour: '2-digit',
+              minute: '2-digit',
+              hour12: true,
+              timeZone: 'America/New_York' // NEW YORK TIME
+            });
+        }
+        return tempTimestamp;
+    };
+
+    //When the data loads, fetches the image of the latest climb to display for the session
+    useEffect(() => {
+        const loadImages = async () => {
+          try {
+            // Default image path
+            let climbImageURL = 'climb photos/the_crag.png';
+    
+            // If there is climb data and images are available, use the latest image
+            if (data[data.length-1] && data[data.length-1].sessionImages && data[data.length-1].sessionImages.length > 0) {
+
+              const latestImageRef = data[data.length-1].sessionImages[0]; //Fetches the first Image, useful when the user sets a new look for the session
+              climbImageURL = latestImageRef.path;
+            }
+            // Load climb image
+            const loadedClimbImageUrl = await loadImageUrl(climbImageURL);
+            setClimbImageUrl(loadedClimbImageUrl);
+            setInitialImagePath(loadedClimbImageUrl);
+          } catch (error) {
+            console.error("Error loading images: ", error);
+          }
+        };
+        loadImages();
+    }, [data]);
+
+
+    const EditButton = ({ onPress }) => {
+        return (
+            <TouchableOpacity style={styles.button} onPress={onPress}>
+                <Icon name="add-photo-alternate" size={20} color="black" />
+                <Text style={{color: 'black', padding: 5, fontSize: 12}}>Add Photos</Text>
+            </TouchableOpacity>
+        );
+    };
+
+    const UpdateButton = ({ onPress }) => {
+        return (
+            <TouchableOpacity style={{width: '100%', backgroundColor: '#3498db', borderRadius: 10, display: 'flex', flexDirection: 'row', paddingVertical: 12, paddingHorizontal: 20, justifyContent: 'center', alignItems: 'center'}} onPress={onPress}>
+                <Text style={{color: 'white', fontSize: 15, textAlign: 'center'}}>Update Session</Text>
+            </TouchableOpacity>
+        );
+    };
+
+
+    //DropDown for Featured Climbs
+    const CollapsibleItem = ({ children }) => {
+        const [isOpen, setIsOpen] = useState(false);
+    
+        const toggleOpen = () => {
+            setIsOpen(!isOpen);
+        };
+    
+        return (
+            <View style={{width: '100%', paddingVertical: 20}}>
+                <TouchableOpacity style={styles.header} onPress={toggleOpen}>
+                    <View style={{display: 'flex', flexDirection :'row'}}>
+                    <Icon name="star-border" size={20} color="#000"/>
+                    <Text style={styles.headerText}>Featured Climb</Text>
+                    </View>
+                    <Icon name={isOpen ? "keyboard-arrow-up" : "keyboard-arrow-down"} size={20} color="#000"/>
+                </TouchableOpacity>
+                {isOpen && (
+                    <View style={styles.content}>
+                        {children}
+                    </View>
+                )}
+            </View>
+        );
+    };    
+
+
+    const handleUpdateSession = () => {
+        Alert.alert(
+            "Confirm Update",
+            "Are you sure you want to update this session?",
+            [
+                {
+                    text: "Cancel",
+                    onPress: () => console.log("Update cancelled"),
+                    style: "cancel"
+                },
+                { 
+                    text: "OK", 
+                    onPress: () => updateSession() 
+                }
+            ],
+            { cancelable: false }
+        );
+    };
+
+    const updateSession = async () => {
+        console.log('Initial image path: ', initialImagePath);
+        console.log('Updated image path: ', climbImageUrl);
+        // Logic to update the session
+        if (initialText !== sessionTitle) {
+            if (sessionTitle.trim() === '') {
+                Alert.alert("Error", "Session title cannot be empty!");
+                return;
+            }
+            try {
+                const { updateTap } = TapsApi();
+                await updateTap(data[data.length-1].tapId, {sessionTitle: sessionTitle});
+                initialText = sessionTitle;
+            } catch (error) {
+                console.error(error);
+                Alert.alert("Error", "Couldn't update session.");
+                return;
+            }
+        }
+        if (initallySelected !== selectedTapId) {
+            try {
+                const { updateTap } = TapsApi();
+                await updateTap(selectedTapId, {isSelected: true});
+                await updateTap(initallySelected, {isSelected: false});
+                initallySelected = selectedTapId;
+            } catch (error) {
+                console.error(error);
+                Alert.alert("Error", "Couldn't update selection.");
+                return;
+            }
+        }
+        if (initialImagePath !== '' && initialImagePath !== climbImageUrl) {
+            try {
+                const uploadedImage = await uploadImage(climbImageUrl);
+                const { updateTap } = TapsApi();
+                await updateTap(data[data.length-1].tapId, {sessionImages: [uploadedImage].concat((data[data.length-1].sessionImages? data[data.length-1].sessionImages: []))});
+                console.log('Image updated for: ', data[data.length-1].tapId);
+                setInitialImagePath(climbImageUrl);
+            } catch (error) {
+                console.error(error);
+                Alert.alert("Error", "Couldn't update image.");
+                return;
+            }
+        }
+        Alert.alert("Success", "Session updated!");
+        console.log("Session updated");
+        navigation.popToTop();
+    };
+
+    const uploadImage = async (imagePath) => {
+        const filename = imagePath.split('/').pop().replace(/\.jpg/gi, "").replace(/-/g, "");
+        const storageRef = storage().ref(`climb_images/${filename}`);
+        await storageRef.putFile(imagePath);
+        return { id: filename, path: storageRef.fullPath, timestamp: new Date().toISOString() };
+    };
+
+
+
+    const selectImageLogic = async () => {
+        console.log("handleImagePick called");
+        try {
+        const pickedImage = await ImagePicker.openPicker({
+            width: 300,
+            height: 400,
+            cropping: true,
+        });
+
+        // Save the full image path for later uploading
+        const imagePath = pickedImage.path;
+
+        // Set the image state to include the full path
+        setClimbImageUrl(imagePath);
+
+        } catch (err) {
+        console.error("Error picking image:", err);
+        }
+    };
+
+  return (
+    <SafeAreaView style={{flex: 1}}>
+    <View style={{display: 'flex', width: '100%', justifyContent: 'center', alignItems: 'center', flexDirection: 'column', flex: 1}}>
+      <ScrollView style={{display: 'flex', flexDirection: 'column', paddingVertical: 10, flex: 1}}>
+        <View style={{display: 'flex', width: '100%', justifyContent: 'center', alignItems: 'center', paddingVertical: 30}}>
+            <TextInput style={styles.textInput} placeholder="" placeholderTextColor='black' defaultValue={initialText} onChangeText={(text) => {setSessionTitle(text.trim())}}/>
+        </View>
+        <View style={{display: 'flex', width: '100%', justifyContent: 'center', alignItems: 'center', padding: 10, flexDirection: 'row'}}>
+            <View style= {{display: 'flex', width: '40%'}}>
+            {climbImageUrl ? <Image source={{ uri: climbImageUrl }} style={{ width: 130, height: 180, borderRadius: 5}} /> : <ActivityIndicator color="#3498db"/>}
+            </View>
+            <View style= {{display: 'flex', width: '40%', height: '100%', paddingHorizontal: 10}}>
+                <EditButton onPress={selectImageLogic}/>
+            </View>
+        </View>
+        <View style={{display: 'flex', width: '100%', justifyContent: 'center', alignItems: 'center', flexDirection: 'row'}}>
+            <CollapsibleItem>
+                <View style={{width: '100%', justifyContent:'flex-start', display:'flex', alignItems: 'center', flexDirection: 'row'}}>
+                <ListHistory
+                data={data}
+                renderItem={(item, index, isHighlighted) => <ClimbItem climb={item} tapId={item.tapId} tapTimestamp={timeStampFormatting(item.tapTimestamp)} fromHome={false} isHighlighted={(item.tapId === selectedTapId && isHighlighted)} sessionPick={true} tapIdRef={tapIdRef} setSelectedTapId={setSelectedTapId}/>}
+                //highlighted variable passed for index 0, only if it is an active session
+                keyExtractor={(item, index) => index.toString()}
+                isHighlighted = {true}
+                />
+                </View>
+            </CollapsibleItem>
+        </View>
+      </ScrollView>
+        <View style={{justifyContent: 'center', alignItems: 'center', padding: 10, width: '100%', paddingHorizontal: 10, backgroundColor: 'white'}}>
+            <UpdateButton onPress={handleUpdateSession}/>
+        </View>
+        </View>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  climbDot: {
+    width: 'auto',
+    height: 'auto',
+    borderRadius: 15,
+    color: 'black',
+    borderColor: '#fe8100',
+    borderWidth: 1,
+    padding: 5,
+    fontSize: 10,
+},
+climbName: {
+    color: 'black',
+    fontSize: 10,
+    padding: 5,
+},
+climbImage: {
+    width: 30,
+    height: 30,
+    borderRadius: 15,
+},
+timerInfo: {
+    borderRadius: 15,
+    alignItems: 'center',
+    justifyContent: 'center',
+    color: 'black',
+    fontSize: 10,
+    padding: 5,
+},
+button: {
+    // Style your button
+    padding: 10,
+    borderRadius: 5,
+    borderWidth: 1,
+    borderRadius: 5,
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: 180,
+    borderColor: '#fe8100',
+    display: 'flex',
+    flexDirection: 'column',
+    borderStyle: 'dashed'
+},
+textInput: {
+    width: '90%', // Width of the TextInput
+    height: 50, // Height of the TextInput
+    borderWidth: 1, // Border to make the TextInput visible
+    borderColor: 'black', // Border color
+    paddingLeft: 10, // Padding inside the TextInput
+    color: 'black',
+    borderRadius: 10,
+    backgroundColor: 'white'
+},
+header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: 15,
+    backgroundColor: 'white',
+    borderRadius: 10,
+    margin:10,
+    // Add additional styling as needed
+},
+headerText: {
+    fontWeight: '500',
+    color: 'black',
+    paddingHorizontal: 10,
+    // Add additional styling as needed
+},
+content: {
+    padding: 0,
+    color: 'black',
+    borderRadius: 10,
+    // Add additional styling for the content area
+}
+});
+
+export default EditSession;

--- a/trk/src/Components/ListItemSessions.js
+++ b/trk/src/Components/ListItemSessions.js
@@ -19,6 +19,7 @@ const styles = StyleSheet.create({
         flexDirection: 'row',
         alignItems: 'center',
         borderRadius: 5,
+        backgroundColor: 'white',
     },
     defaultDot: {
         borderRadius: 5,
@@ -35,6 +36,7 @@ const styles = StyleSheet.create({
         borderColor: '#fe8100',
         borderWidth: 1,
         padding: 5,
+        backgroundColor: 'white',
         
     },
 });

--- a/trk/src/Components/SessionDetail.js
+++ b/trk/src/Components/SessionDetail.js
@@ -1,0 +1,311 @@
+import React, { useState, useContext, useEffect, useCallback, useMemo} from "react";
+import { View, Text, Button, TextInput, StyleSheet, Alert, TouchableOpacity, ScrollView, SafeAreaView } from "react-native";
+import firestore from '@react-native-firebase/firestore';
+import { AuthContext } from "../Utils/AuthContext";
+import { useNavigation } from '@react-navigation/native';
+import storage from '@react-native-firebase/storage';
+import ListItemSessions from "./ListItemSessions";
+import { Image } from "react-native";
+import ClimbItem from "./ClimbItem";
+import ListHistory from "./ListHistory";
+import { FlatList } from "react-native-gesture-handler";
+import { ActivityIndicator } from "react-native-paper";
+import {Modal} from "react-native-paper";
+import Icon from 'react-native-vector-icons/MaterialIcons'; // Or any other icon family you prefer
+
+const SessionDetail = ({route}) => {
+  const navigation = useNavigation();
+  let data = route.params.data;
+  const title = route.params.title;
+  //data[0].images = [{path: 'climb photos/the_crag.png'},{path: 'climb photos/the_crag.png'},{path: 'climb photos/the_crag.png'},{path: 'climb photos/the_crag.png'}];
+  const allImages = useMemo(() => {
+    return data.flatMap(item => item.sessionImages ? item.sessionImages : []);
+  }, [data]);  
+  console.log('All Images: ', allImages);
+  let initallySelected = null;
+  let initialText = null;
+  let selectedData = null;
+  console.log(data);
+  //Selected Item Set
+  if (data.length>0) {
+      selectedData = data.filter(obj => obj.isSelected == true);
+      console.log('The selected Data is: ', selectedData);
+      if (selectedData.length == 0) {
+          initallySelected = data[0].tapId;
+          selectedData = [data[0]];
+          console.log('Initially selected value is: ', initallySelected);
+      } else {
+          initallySelected = selectedData[0].tapId;
+          console.log('Initially selected value is: ', initallySelected);
+      }
+      if (data[data.length-1].sessionTitle === undefined || (data[data.length-1].sessionTitle && data[data.length-1].sessionTitle === '')) {
+          initialText = 'Session on '+title[1];
+      }
+      else {
+          initialText = data[data.length-1].sessionTitle;
+      }
+      console.log('Initial session text: ', initialText);
+  }
+
+  const [climbImageUrl, setClimbImageUrl] = useState(null);
+  const { currentUser } = useContext(AuthContext);
+
+  const [selectedImage, setSelectedImage] = useState(null);
+  const [modalVisible, setModalVisible] = useState(false);
+  
+  const handleImagePress = useCallback((imageUrl) => {
+        setSelectedImage(imageUrl);
+        setModalVisible(true);
+  }, [setSelectedImage, setModalVisible]);  
+
+
+    //To fetch the climb image of the latest climb
+    const loadImageUrl = async (imagePath) => {
+        try {
+          const url = await storage().ref(imagePath).getDownloadURL();
+          return url;
+        } catch (error) {
+          console.error("Error getting image URL: ", error);
+          throw error;
+        }
+    };
+
+    const calculateDuration = (data) => {
+        if (data.length < 2) {
+            return '0 minutes';
+        }
+    
+        // Assuming timestamps are in milliseconds
+        const firstTimestamp = data[0].timestamp; // Most recent
+        const lastTimestamp = data[data.length - 1].timestamp; // Oldest
+    
+        // Calculate the difference in hours
+        const differenceInHours = (firstTimestamp - lastTimestamp) / (1000 * 60 * 60);
+    
+        // If the difference is less than an hour, return in minutes
+        if (differenceInHours < 1) {
+            const differenceInMinutes = Math.round((firstTimestamp - lastTimestamp) / (1000 * 60));
+            return `${differenceInMinutes} mins`;
+        }
+    
+        // Otherwise, round to the nearest half hour and return in hours
+        const roundedHours = Math.round(differenceInHours * 2) / 2;
+        return `${roundedHours} hrs`;
+    };
+    
+    
+    
+    //Time stamp formatting like Home Page for clarity (Altered ClimbItem to match)
+    const timeStampFormatting = (timestamp) => {
+        let tempTimestamp = null;
+        if (timestamp.toDate) { // Convert Firebase Timestamp to JavaScript Date
+            tempTimestamp = timestamp.toDate().toLocaleTimeString('en-US', {
+              hour: '2-digit',
+              minute: '2-digit',
+              hour12: true,
+              timeZone: 'America/New_York' // NEW YORK TIME
+            });
+        }
+        return tempTimestamp;
+    };
+
+    //When the data loads, fetches the image of the latest climb to display for the session
+    useEffect(() => {
+        const loadImages = async () => {
+          try {
+            // Default image path
+            let climbImageURL = 'climb photos/the_crag.png';
+    
+            // If there is climb data and images are available, use the latest image
+            if (data[data.length-1] && data[data.length-1].sessionImages && data[data.length-1].sessionImages.length > 0) {
+
+              const latestImageRef = data[data.length-1].sessionImages[0]; //Fetches the first Image, useful when the user sets a new look for the session
+              climbImageURL = latestImageRef.path;
+            }
+            // Load climb image
+            const loadedClimbImageUrl = await loadImageUrl(climbImageURL);
+            setClimbImageUrl(loadedClimbImageUrl);
+          } catch (error) {
+            console.error("Error loading images: ", error);
+          }
+        };
+        loadImages();
+    }, [data]);
+
+
+    const EditButton = ({ onPress }) => {
+        return (
+            <TouchableOpacity style={styles.button} onPress={onPress}>
+                <Icon name="more-horiz" size={20} color="black" />
+            </TouchableOpacity>
+        );
+    };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <ScrollView style={{display: 'flex', flexDirection: 'column', paddingVertical: 10}}>
+      <View style={{height: 150, width: '100%', backgroundColor: 'transparent', borderRadius: 10, display: 'flex', flexDirection: 'row'}}>
+                <View style={{width: '30%', display: 'flex', justifyContent: 'center', alignItems: 'center', padding: 10}}>
+                {climbImageUrl ? <Image source={{ uri: climbImageUrl }} style={{ width: '100%', height: '100%', borderRadius: 5}} /> : <ActivityIndicator color="#3498db"/>}
+                </View>
+                <View style={{width: '70%', display: 'flex', justifyContent: 'flex-start', alignItems: 'center', paddingRight: 10, paddingVertical: 10}}>
+                    <View style={{width: '100%', justifyContent:'center', display:'flex', alignItems: 'flex-start'}}>
+                        <Text style={{color: 'black', fontSize: 15, fontWeight: '500'}}>{initialText}</Text>
+                        <Text style={{color: 'black', fontSize: 12}}>{title[0]}</Text>
+                        <Text style={{color: 'black', fontSize: 12}}>{title[1]}</Text>
+                    </View>
+                    <View style={{width: '100%', height: '70%', display: 'flex', flexDirection: 'row', paddingTop: 10}}>
+                        <View style={{width: '50%', padding: 10, display:'flex', justifyContent: 'center', alignItems: 'center'}}>
+                            <Text style={{color: 'black', fontSize: 25, fontWeight: '500'}}>{data.length}</Text>
+                            <Text style={{color: 'black', fontSize: 12}}>Total Climbs</Text>
+                        </View>
+                        <View style={{width: '50%', display: 'flex', justifyContent: 'flex-start', alignItems: 'center'}}>
+                            <View style={{marginRight: 10}}>
+                                <ListItemSessions dotStyle={styles.climbDot} grade={selectedData[0].grade}>
+                                    <Text style={styles.climbName}>{selectedData[0].name}</Text>
+                                    <View>
+                                    <Text style={styles.timerInfo}>
+                                        {timeStampFormatting(selectedData[0].tapTimestamp).replace(/AM|PM/i, '').trim()}
+                                    </Text>
+                                    </View>
+                                </ListItemSessions>
+                            </View>
+                            <Text style={{color: 'black', padding: 5, fontSize: 12}}>Last Climb</Text>
+                        </View>
+                    </View>
+                </View>
+        </View>
+        <View style={{width: '100%', justifyContent:'center', display:'flex', alignItems: 'center', flexDirection: 'row'}}>
+            <View style={{display: 'flex', width: '30%', height: 10}}></View>
+            <View style={{display: 'flex', width: '40%', justifyContent: 'center', alignItems: 'center', padding: 20}}>
+            <Text style={{color: 'black', fontSize: 25, fontWeight: '500'}}>{calculateDuration(data)}</Text>
+            <Text style={{color: 'black', fontSize: 12}}>Session Duration</Text>
+            </View>
+            <View style={{display: 'flex', width: '30%', justifyContent: 'center', alignItems: 'center', padding: 20}}>
+                <EditButton onPress={() => {navigation.navigate('Edit_Session', {data: data, title: title})}}/>
+            </View>
+        </View>
+        <View style={{width: '100%', justifyContent:'flex-start', display:'flex', alignItems: 'center', flexDirection: 'row', paddingTop: 10}}>
+            <Text style={{color: 'black', paddingHorizontal: 20, fontWeight: 'bold'}}>{allImages.length>0? 'All Media': 'No Media'}</Text>
+        </View>
+        <View style={{width: '100%', justifyContent:'flex-start', display:'flex', alignItems: 'center', flexDirection: 'row', padding: 10}}>
+            <FlatList
+                data={allImages}
+                horizontal={true}
+                renderItem={({ item }) => (
+                    <TouchableOpacity onPress={() => {handleImagePress(item.path)}}>
+                    <ImageItem imagePath={item.path} />
+                    </TouchableOpacity>
+                )}
+                keyExtractor={(item, index) => index.toString()}
+            />
+        </View>
+        <View style={{width: '100%', justifyContent:'flex-start', display:'flex', alignItems: 'center', flexDirection: 'row', paddingTop: 10}}>
+            <Text style={{color: 'black', paddingHorizontal: 20, fontWeight: 'bold'}}>Climb Details</Text>
+        </View>
+        <View style={{width: '100%', justifyContent:'flex-start', display:'flex', alignItems: 'center', flexDirection: 'row'}}>
+            <ListHistory
+            data={data}
+            renderItem={(item, index, isHighlighted) => <ClimbItem climb={item} tapId={item.tapId} tapTimestamp={timeStampFormatting(item.tapTimestamp)} fromHome={false} isHighlighted={(index == 0 && isHighlighted)}/>}
+            //highlighted variable passed for index 0, only if it is an active session
+            keyExtractor={(item, index) => index.toString()}
+            isHighlighted = {false}
+            />
+        </View>
+      </ScrollView>
+      <ImageModal visible={modalVisible} onClose={() => setModalVisible(false)} imagePath={selectedImage}/>
+    </SafeAreaView>
+  );
+};
+
+const loadImageUrl = async (imagePath) => {
+    try {
+      const url = await storage().ref(imagePath).getDownloadURL();
+      return url;
+    } catch (error) {
+      console.error("Error getting image URL: ", error);
+      throw error;
+    }
+};
+
+const ImageItem = ({ imagePath, isModal = false}) => {
+    const [imageUrl, setImageUrl] = useState(null);
+
+    useEffect(() => {
+        const fetchImageUrl = async () => {
+            const url = await loadImageUrl(imagePath);
+            setImageUrl(url);
+        };
+
+        fetchImageUrl();
+    }, [imagePath]);
+
+    if (!imageUrl) {
+        // Show placeholder or spinner
+        return <View style={{display: 'flex', justifyContent: 'center', alignItems: 'center', width: 130, height: 180}}><ActivityIndicator color="#3498db"/></View>; // Replace with your spinner or placeholder component
+    }
+    if (!isModal){
+        return (
+            <Image source={{ uri: imageUrl }} style={{ width: 130, height: 180, marginHorizontal: 5, borderRadius: 5}} />
+        );
+    } else {
+        return (
+            <Image source={{ uri: imageUrl }} style={{ width: 200, height: 300, borderRadius: 5}} />
+        );
+    }
+};
+
+const ImageModal = ({ visible, onClose, imagePath }) => {
+    return (
+      <Modal
+        visible={visible}
+        onDismiss={onClose}
+        contentContainerStyle={styles.modalContainer}
+        style={{width: '100%', height: '100%', display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center'}}
+      >
+        <ImageItem imagePath={imagePath} isModal={true} />
+      </Modal>
+    );
+  };
+  
+
+
+const styles = StyleSheet.create({
+  climbDot: {
+    width: 'auto',
+    height: 'auto',
+    borderRadius: 15,
+    color: 'black',
+    borderColor: '#fe8100',
+    borderWidth: 1,
+    padding: 5,
+    fontSize: 10,
+},
+climbName: {
+    color: 'black',
+    fontSize: 10,
+    padding: 5,
+},
+climbImage: {
+    width: 30,
+    height: 30,
+    borderRadius: 15,
+},
+timerInfo: {
+    borderRadius: 15,
+    alignItems: 'center',
+    justifyContent: 'center',
+    color: 'black',
+    fontSize: 10,
+    padding: 5,
+},
+button: {
+    // Style your button
+    padding: 5,
+    borderRadius: 5,
+    alignItems: 'center',
+    justifyContent: 'center',
+},
+});
+
+export default SessionDetail;

--- a/trk/src/Components/SessionItem.js
+++ b/trk/src/Components/SessionItem.js
@@ -10,7 +10,7 @@ import { AuthContext } from '../Utils/AuthContext';
 import ClimbItem from './ClimbItem';
 import ListItemSessions from './ListItemSessions';
 import { TouchableOpacity } from 'react-native-gesture-handler';
-
+import { useNavigation } from '@react-navigation/native';
 
 const styles = StyleSheet.create({
     climbDot: {
@@ -45,10 +45,36 @@ const styles = StyleSheet.create({
 
 const SessionItem = ({ data, title, renderItem, keyExtractor, isHighlighted}) => {
     console.log('[TEST] ListHistory called');
-    if (!data) {
+    if (!data || (data && data.length == 0)) {
         return;
     }   
     console.log('Data in the Session is: ', data);
+        
+    //Session Edits implemented
+        let initallySelected = null;
+        let initialText = null;
+        let selectedData = null;
+        console.log(data);
+        //Selected Item Set
+        if (data.length>0) {
+            selectedData = data.filter(obj => obj.isSelected == true);
+            console.log('The selected Data is: ', selectedData);
+            if (selectedData.length == 0) {
+                initallySelected = data[0].tapId;
+                selectedData = [data[0]];
+                console.log('Initially selected value is: ', initallySelected);
+            } else {
+                initallySelected = selectedData[0].tapId;
+                console.log('Initially selected value is: ', initallySelected);
+            }
+            if (data[data.length-1].sessionTitle === undefined || (data[data.length-1].sessionTitle && data[data.length-1].sessionTitle === '')) {
+                initialText = 'Session on '+title[1];
+            }
+            else {
+                initialText = data[data.length-1].sessionTitle;
+            }
+            console.log('Initial session text: ', initialText);
+        }
 
     const [climbImageUrl, setClimbImageUrl] = useState(null);
     const {currentUser} = useContext(AuthContext);
@@ -85,8 +111,8 @@ const SessionItem = ({ data, title, renderItem, keyExtractor, isHighlighted}) =>
             let climbImageURL = 'climb photos/the_crag.png';
     
             // If there is climb data and images are available, use the latest image
-            if (data[0] && data[0].images && data[0].images.length > 0) {
-              const latestImageRef = data[0].images[0]; //Fetches the first Image, useful when the user sets a new look for the session
+            if (data[data.length-1] && data[data.length-1].sessionImages && data[data.length-1].sessionImages.length > 0) {
+              const latestImageRef = data[data.length-1].sessionImages[0]; //Fetches the first Image, useful when the user sets a new look for the session
               climbImageURL = latestImageRef.path;
             }
     
@@ -100,17 +126,20 @@ const SessionItem = ({ data, title, renderItem, keyExtractor, isHighlighted}) =>
         loadImages();
     }, [data]);
 
+    const navigation = useNavigation();
+
     return (
         <ScrollView contentContainerStyle={{ padding: 10}}>
-            <TouchableOpacity onPress={() => {console.log('Session Clicked: ', data)}}>
+            <TouchableOpacity onPress={() => {navigation.navigate('Session_Detail', {data: data, title: title})}}>
             <View style={{height: 150, width: '100%', backgroundColor: 'white', borderRadius: 10, display: 'flex', flexDirection: 'row'}}>
                 <View style={{width: '30%', display: 'flex', justifyContent: 'center', alignItems: 'center', padding: 10}}>
                 {climbImageUrl ? <Image source={{ uri: climbImageUrl }} style={{ width: '100%', height: '100%', borderRadius: 5}} /> : <Text style={{color: 'black', fontSize: 8}}>Loading...</Text>}
                 </View>
                 <View style={{width: '70%', display: 'flex', justifyContent: 'flex-start', alignItems: 'center', paddingRight: 10, paddingVertical: 10}}>
                     <View style={{width: '100%', justifyContent:'center', display:'flex', alignItems: 'flex-start'}}>
-                        <Text style={{color: 'black', fontSize: 15, fontWeight: '500'}}>Session on {title[1]}</Text>
+                        <Text style={{color: 'black', fontSize: 15, fontWeight: '500'}}>{initialText}</Text>
                         <Text style={{color: 'black', fontSize: 12}}>{title[0]}</Text>
+                        <Text style={{color: 'black', fontSize: 12}}>{title[1]}</Text>
                     </View>
                     <View style={{width: '100%', height: '70%', display: 'flex', flexDirection: 'row', paddingTop: 10}}>
                     <View style={{width: '50%', padding: 10, display:'flex', justifyContent: 'center', alignItems: 'center'}}>
@@ -119,11 +148,11 @@ const SessionItem = ({ data, title, renderItem, keyExtractor, isHighlighted}) =>
                     </View>
                     <View style={{width: '50%', display: 'flex', justifyContent: 'flex-start', alignItems: 'center'}}>
                         <View style={{marginRight: 10}}>
-                            <ListItemSessions dotStyle={styles.climbDot} grade={data[0].grade}>
-                                <Text style={styles.climbName}>{data[0].name}</Text>
+                            <ListItemSessions dotStyle={styles.climbDot} grade={selectedData[0].grade}>
+                                <Text style={styles.climbName}>{selectedData[0].name}</Text>
                                 <View>
                                 <Text style={styles.timerInfo}>
-                                    {timeStampFormatting(data[0].tapTimestamp).replace(/AM|PM/i, '').trim()}
+                                    {timeStampFormatting(selectedData[0].tapTimestamp).replace(/AM|PM/i, '').trim()}
                                 </Text>
                                 </View>
                             </ListItemSessions>

--- a/trk/src/Components/SessionTapHistory.js
+++ b/trk/src/Components/SessionTapHistory.js
@@ -97,9 +97,10 @@ const SessionTapHistory = (props) => {
     
     const groupedClimbs = props.currentSession;
     //Changes in display for active session (not empty), active session (empty), and the remaining sessions (Session class created in next PR).
+    //Minor changes to ordering
     return (
         <ScrollView>
-            {Object.entries(groupedClimbs).reverse().map(([key, climbs]) => (
+            {Object.entries(groupedClimbs).map(([key, climbs]) => (
                 <View key={key}>
                     <View style={{paddingVertical: 5, paddingHorizontal: 20}}>
                         {(props.isCurrent && climbs && climbs.length > 0) && (
@@ -121,7 +122,7 @@ const SessionTapHistory = (props) => {
                     </View>
                     {props.isCurrent && 
                         (<ListHistory
-                        data={climbs}
+                        data={climbs.reverse()}
                         renderItem={(item, index, isHighlighted) => <ClimbItem climb={item} tapId={item.tapId} tapTimestamp={timeStampFormatting(item.tapTimestamp)} fromHome={props.fromHome} isHighlighted={(index == 0 && isHighlighted)}/>}
                         //highlighted variable passed for index 0, only if it is an active session
                         keyExtractor={(item, index) => index.toString()}

--- a/trk/src/Navigation/AppNavigator.js
+++ b/trk/src/Navigation/AppNavigator.js
@@ -25,6 +25,8 @@ import LiveClimbTracker from '../Screens/LiveClimbTracker';
 import RecordScreen from '../Screens/TabScreens/Record/Frontend';
 import messaging from '@react-native-firebase/messaging';
 import Toast from 'react-native-toast-message';
+import SessionDetail from '../Components/SessionDetail';
+import EditSession from '../Components/Edit_Session';
 
 
 const Stack = createStackNavigator();
@@ -217,6 +219,24 @@ function ProfileStack() {
         name="Developer_Feedback"
         component={DeveloperFeedbackForm}
         options={{ title: 'Developer Feedback', headerTitleAlign: 'center' }}
+      />
+      <Stack.Screen
+        name="Session_Detail"
+        component={SessionDetail}
+        options={({ navigation }) => ({ title: 'Session', headerTitleAlign: 'center', headerRight: () => (
+          <FeedbackButton
+                title="Feedback"
+                navigation={navigation}
+          />) })}
+      />
+      <Stack.Screen
+        name="Edit_Session"
+        component={EditSession}
+        options={({ navigation }) => ({ title: 'Edit Session', headerTitleAlign: 'center', headerRight: () => (
+          <FeedbackButton
+                title="Feedback"
+                navigation={navigation}
+          />) })}
       />
       <Stack.Screen
         name="Detail"

--- a/trk/src/Screens/NavScreens/ClimbDetail/Backend/ClimbDetailLogic.js
+++ b/trk/src/Screens/NavScreens/ClimbDetail/Backend/ClimbDetailLogic.js
@@ -140,7 +140,8 @@ export const archiveTap = async (navigation, tapId) => {
           try {
             await TapsApi().updateTap(tapId, { archived: true });
             Alert.alert("Tap Deleted", "The tap has been successfully deleted.");
-            navigation.goBack();
+            //To reach the top of the stack (for refreshing of sessions)
+            navigation.popToTop();
           } catch (error) {
             console.error("Error deleting tap:", error);
             Alert.alert("Error", "Could not delete tap.");

--- a/trk/src/Screens/TabScreens/Profile/Backend/ClimberProfile.js
+++ b/trk/src/Screens/TabScreens/Profile/Backend/ClimberProfile.js
@@ -61,7 +61,7 @@ const ClimberProfile = ({ navigation }) => {
             const tapsSnapshot = await getExpiredTaps(currentUser.uid);
             // Filter taps
             const filteredTaps = tapsSnapshot.docs
-                .map(doc => ({ id: doc.id, ...doc.data() })) // Convert to tap objects
+                .map(doc => ({ id: doc.id, ...doc.data() })) // Convert to tap objects,
                 .filter(tap => tap !== null && (tap.archived === undefined || tap.archived === false)); // Apply the filter
 
             //Filtering active session taps
@@ -83,9 +83,10 @@ const ClimberProfile = ({ navigation }) => {
             const activeClimbsSnapshots = await Promise.all(activeClimbPromises);
 
             // Combine climb details with tap data
+            //Added session info to expired climbs
             const newClimbsHistory = climbsSnapshots.map((climbSnapshot, index) => {
                 if (!climbSnapshot.exists) return null;
-                return { ...climbSnapshot.data(), tapId: filteredTaps[index].id, tapTimestamp: filteredTaps[index].timestamp};
+                return { ...climbSnapshot.data(), tapId: filteredTaps[index].id, tapTimestamp: filteredTaps[index].timestamp, isSelected: filteredTaps[index].isSelected, sessionTitle: filteredTaps[index].sessionTitle, sessionImages: filteredTaps[index].sessionImages, isSessionStart: filteredTaps[index].isSessionStart};
             }).filter(climb => climb !== null && (climb.archived === undefined || climb.archived === false));
 
 
@@ -176,7 +177,7 @@ const ClimberProfile = ({ navigation }) => {
             console.log('I starts at: ', i);
         }
         else {
-            console.log('I starts at: ', i);
+            console.log('I is: ', i); //To document pagination
         }
         // Iterate from the oldest to the newest climb
         for (; i < climbs.length; i++) { //Can iterate through
@@ -190,7 +191,7 @@ const ClimberProfile = ({ navigation }) => {
                 currentSessionClimbs.push(climb);
 
                 // When a climb marks the start of a session or is the startingClimb
-                if (climb.isSessionStart || (startingClimb && climb.tapId === startingClimb.tapId)) {
+                if (climb.isSessionStart == true|| (startingClimb && climb.tapId === startingClimb.tapId)) {
                     // Use the timestamp of the current climb to create a session key
                     sessionKey = moment(climbDate).tz('America/New_York').format('YYYY-MM-DD HH:mm');
                     expiredSessions[sessionKey] = [...currentSessionClimbs];
@@ -204,7 +205,7 @@ const ClimberProfile = ({ navigation }) => {
 
         //console.log('Session Timestamp: ', sessionKey);
         const activeSession = {};
-        activeSession[activeSessionTimestamp] = activeClimbs;
+        activeSession[activeSessionTimestamp] = activeClimbs.reverse(); //For desc ordering of active session taps
         console.log('Expired Session is: ', expiredSessions);
         console.log('Active Session is: ', activeSession);
         return {expiredSessions, activeSession, activeSessionTimestamp};


### PR DESCRIPTION
- Sessions can now be accessed in a new Screen (they are updated when taps within them are deleted, take you back to Profile tab)
- Can see duration, media, basic stats (from Figma). Climbs can be added or removed within SessionDetail.js
- Sessions can be edited (Adding media, changing title, displayed climb). Even when the session header node is deleted, this info is passed on to other items in the session (immutable)
- Fixed some minor UI bugs

https://github.com/nagimonyc/trk-app/assets/75244191/a7edec55-bab1-4eaa-a826-658c3e8d6cad

