### PR TITLE
Making the Active session a Session Item (for tagging ease)

### DIFF
--- a/trk/src/Components/SessionTapHistory.js
+++ b/trk/src/Components/SessionTapHistory.js
@@ -121,12 +121,9 @@ const SessionTapHistory = (props) => {
                         )}
                     </View>
                     {props.isCurrent && 
-                        (<ListHistory
-                        data={climbs.reverse()}
-                        renderItem={(item, index, isHighlighted) => <ClimbItem climb={item} tapId={item.tapId} tapTimestamp={timeStampFormatting(item.tapTimestamp)} fromHome={props.fromHome} isHighlighted={(index == 0 && isHighlighted)}/>}
-                        //highlighted variable passed for index 0, only if it is an active session
-                        keyExtractor={(item, index) => index.toString()}
-                        isHighlighted = {props.isCurrent}
+                        (<SessionItem
+                        data={climbs}
+                        title={sessionTimestamp(key)}
                         />)
                     }
                     {!props.isCurrent && 


### PR DESCRIPTION
- Based on the conversation we had on 01/26/2024 (How will climbers tag people as they work with them?)
- Just converted the climbs in an active session to a SessionItem.

![WhatsApp Image 2024-01-27 at 8 32 28 PM](https://github.com/nagimonyc/trk-app/assets/75244191/627c055b-d5e2-41f2-8eef-23ffce5c0501)
