### PR TITLE
[GEN-997] Community Backward Navigation

### DIFF
--- a/trk/src/Navigation/AppNavigator.js
+++ b/trk/src/Navigation/AppNavigator.js
@@ -280,6 +280,11 @@ function CollectionStack() {
         component={DeveloperFeedbackForm}
         options={{ title: 'Developer Feedback', headerTitleAlign: 'center' }}
       />
+            <Stack.Screen
+        name="Community"
+        component={Community}
+        options={{ title: 'Community Posts', headerBackTitle: 'Collection', headerTitleAlign: 'center' }}
+      />
       <Stack.Screen
         name="Feedback"
         component={FeedbackForm}


### PR DESCRIPTION
### Summary
**Problem** :  the back button on community always navigated back to record (even when coming from collection)
**Solution** : added community to the collection stack with its own backtitle
N.B.: still correctly navigates back to record when coming from record

### Video

https://github.com/nagimonyc/trk-app/assets/126114238/a0ed3803-88d2-49ad-a8f3-13005bbe9d31

